### PR TITLE
[뷰] 1-1. 홈 화면이 제공되어야 한다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -42,6 +42,11 @@
 		4ACA523B272FCF3C00EC0531 /* AlarmSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA523A272FCF3C00EC0531 /* AlarmSettingViewController.swift */; };
 		4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA523C272FCF4300EC0531 /* MovingStatusViewController.swift */; };
 		4ACA5245272FD52D00EC0531 /* BBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5244272FD52D00EC0531 /* BBusTests.swift */; };
+		87359B8B2730F0F000F461A7 /* SearchBusPushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */; };
+		873D6396273039E100E79069 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D6395273039E100E79069 /* Coordinator.swift */; };
+		873D639827303A6800E79069 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D639727303A6800E79069 /* AppCoordinator.swift */; };
+		873D639A27303B0500E79069 /* HomeCoornicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D639927303B0500E79069 /* HomeCoornicator.swift */; };
+		873D639C27303B5000E79069 /* SearchBusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D639B27303B5000E79069 /* SearchBusCoordinator.swift */; };
 		87A5556C2728116400A9B5E3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A5556B2728116400A9B5E3 /* AppDelegate.swift */; };
 		87A5556E2728116400A9B5E3 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A5556D2728116400A9B5E3 /* SceneDelegate.swift */; };
 		87A555702728116400A9B5E3 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A5556F2728116400A9B5E3 /* HomeViewController.swift */; };
@@ -96,6 +101,11 @@
 		4ACA523C272FCF4300EC0531 /* MovingStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusViewController.swift; sourceTree = "<group>"; };
 		4ACA5242272FD52D00EC0531 /* BBusTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BBusTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ACA5244272FD52D00EC0531 /* BBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BBusTests.swift; sourceTree = "<group>"; };
+		87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBusPushable.swift; sourceTree = "<group>"; };
+		873D6395273039E100E79069 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		873D639727303A6800E79069 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		873D639927303B0500E79069 /* HomeCoornicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoornicator.swift; sourceTree = "<group>"; };
+		873D639B27303B5000E79069 /* SearchBusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBusCoordinator.swift; sourceTree = "<group>"; };
 		87A555682728116400A9B5E3 /* BBus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BBus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		87A5556B2728116400A9B5E3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		87A5556D2728116400A9B5E3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -127,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				87A5556F2728116400A9B5E3 /* HomeViewController.swift */,
+				873D639927303B0500E79069 /* HomeCoornicator.swift */,
 				4ACA51E1272FCD7900EC0531 /* Model */,
 				4ACA51E0272FCD7100EC0531 /* UseCase */,
 				4ACA51DF272FCD6B00EC0531 /* ViewModel */,
@@ -139,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA5232272FCF0F00EC0531 /* SearchBusViewController.swift */,
+				873D639B27303B5000E79069 /* SearchBusCoordinator.swift */,
 				4ACA51ED272FCDD900EC0531 /* Model */,
 				4ACA51EC272FCDD000EC0531 /* UseCase */,
 				4ACA51EB272FCDCA00EC0531 /* ViewModel */,
@@ -439,6 +451,16 @@
 			path = BBusTests;
 			sourceTree = "<group>";
 		};
+		873D6394273039C400E79069 /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				873D6395273039E100E79069 /* Coordinator.swift */,
+				873D639727303A6800E79069 /* AppCoordinator.swift */,
+				87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
 		87A5555F2728116400A9B5E3 = {
 			isa = PBXGroup;
 			children = (
@@ -460,6 +482,7 @@
 		87A5556A2728116400A9B5E3 /* BBus */ = {
 			isa = PBXGroup;
 			children = (
+				873D6394273039C400E79069 /* Coordinator */,
 				4ACA51D7272FCC4E00EC0531 /* Home */,
 				4ACA51D8272FCC5A00EC0531 /* SearchBus */,
 				4ACA51D9272FCC8600EC0531 /* SearchStation */,
@@ -590,6 +613,7 @@
 				4ACA5221272FCEAF00EC0531 /* AlarmSettingUseCase.swift in Sources */,
 				4ACA51F1272FCDF200EC0531 /* SearchBusUseCase.swift in Sources */,
 				4ACA5239272FCF3200EC0531 /* StationViewController.swift in Sources */,
+				873D6396273039E100E79069 /* Coordinator.swift in Sources */,
 				4ACA51F5272FCE0200EC0531 /* SearchBusView.swift in Sources */,
 				4ACA520D272FCE6500EC0531 /* BusRouteView.swift in Sources */,
 				4ACA51E3272FCD9600EC0531 /* HomeModel.swift in Sources */,
@@ -598,10 +622,13 @@
 				4ACA5225272FCEBF00EC0531 /* AlarmSettingView.swift in Sources */,
 				4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */,
 				4ACA5237272FCF2C00EC0531 /* BusRouteViewController.swift in Sources */,
+				873D639827303A6800E79069 /* AppCoordinator.swift in Sources */,
 				4ACA5217272FCE8E00EC0531 /* StationViewModel.swift in Sources */,
 				4ACA51F3272FCDF900EC0531 /* SearchBusViewModel.swift in Sources */,
 				87A555702728116400A9B5E3 /* HomeViewController.swift in Sources */,
 				4ACA5207272FCE5200EC0531 /* BusRouteModel.swift in Sources */,
+				87359B8B2730F0F000F461A7 /* SearchBusPushable.swift in Sources */,
+				873D639A27303B0500E79069 /* HomeCoornicator.swift in Sources */,
 				4ACA5201272FCE3100EC0531 /* SearchStationView.swift in Sources */,
 				4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */,
 				4ACA51FB272FCE1D00EC0531 /* SearchStationModel.swift in Sources */,
@@ -609,6 +636,7 @@
 				4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */,
 				4ACA5223272FCEB500EC0531 /* AlarmSettingViewModel.swift in Sources */,
 				4ACA5235272FCF2100EC0531 /* SearchStationViewController.swift in Sources */,
+				873D639C27303B5000E79069 /* SearchBusCoordinator.swift in Sources */,
 				4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */,
 				4ACA522D272FCEDB00EC0531 /* MovingStatusUseCase.swift in Sources */,
 				4ACA5209272FCE5A00EC0531 /* BusRouteUseCase.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A04682227327843008D87CE /* BusRoutePushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682127327843008D87CE /* BusRoutePushable.swift */; };
+		4A04682427327876008D87CE /* BusRouteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682327327876008D87CE /* BusRouteCoordinator.swift */; };
 		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
 		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
 		4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */; };
@@ -69,6 +71,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A04682127327843008D87CE /* BusRoutePushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRoutePushable.swift; sourceTree = "<group>"; };
+		4A04682327327876008D87CE /* BusRouteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteCoordinator.swift; sourceTree = "<group>"; };
 		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
 		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
 		4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -183,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA5236272FCF2C00EC0531 /* BusRouteViewController.swift */,
+				4A04682327327876008D87CE /* BusRouteCoordinator.swift */,
 				4ACA5205272FCE3C00EC0531 /* Model */,
 				4ACA5204272FCE3900EC0531 /* UseCase */,
 				4ACA5203272FCE3700EC0531 /* ViewModel */,
@@ -468,6 +473,7 @@
 			children = (
 				873D6395273039E100E79069 /* Coordinator.swift */,
 				873D639727303A6800E79069 /* AppCoordinator.swift */,
+				4A04682127327843008D87CE /* BusRoutePushable.swift */,
 				87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */,
 			);
 			path = Coordinator;
@@ -652,6 +658,7 @@
 				4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */,
 				4ACA5223272FCEB500EC0531 /* AlarmSettingViewModel.swift in Sources */,
 				4ACA5235272FCF2100EC0531 /* SearchStationViewController.swift in Sources */,
+				4A04682427327876008D87CE /* BusRouteCoordinator.swift in Sources */,
 				873D639C27303B5000E79069 /* SearchBusCoordinator.swift in Sources */,
 				4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */,
 				4ACA522D272FCEDB00EC0531 /* MovingStatusUseCase.swift in Sources */,
@@ -659,6 +666,7 @@
 				4ACA5233272FCF0F00EC0531 /* SearchBusViewController.swift in Sources */,
 				4ACA51FF272FCE2700EC0531 /* SearchStationViewModel.swift in Sources */,
 				87A5556C2728116400A9B5E3 /* AppDelegate.swift in Sources */,
+				4A04682227327843008D87CE /* BusRoutePushable.swift in Sources */,
 				4ACA522B272FCED600EC0531 /* MovingStatusModel.swift in Sources */,
 				4ACA51FD272FCE2200EC0531 /* SearchStationUseCase.swift in Sources */,
 				87A5556E2728116400A9B5E3 /* SceneDelegate.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
 		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
 		4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */; };
 		4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */; };
@@ -68,6 +69,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
 		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
 		4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusCellTrailingView.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */,
 				4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */,
 				4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */,
+				4A1A22DA27326FD100476861 /* HomeNavigationView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -628,6 +631,7 @@
 				4ACA51E3272FCD9600EC0531 /* HomeModel.swift in Sources */,
 				4ACA51E9272FCDAE00EC0531 /* HomeView.swift in Sources */,
 				4ACA521F272FCEAA00EC0531 /* AlarmSettingModel.swift in Sources */,
+				4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */,
 				4ACA5225272FCEBF00EC0531 /* AlarmSettingView.swift in Sources */,
 				4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */,
 				4ACA5237272FCF2C00EC0531 /* BusRouteViewController.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
-		4A992C49273124AF0006FB8C /* FavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */; };
+		4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */; };
 		4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */; };
 		4ACA51E3272FCD9600EC0531 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E2272FCD9600EC0531 /* HomeModel.swift */; };
 		4ACA51E5272FCD9C00EC0531 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */; };
@@ -69,7 +69,7 @@
 
 /* Begin PBXFileReference section */
 		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
-		4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
+		4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusCellTrailingView.swift; sourceTree = "<group>"; };
 		4ACA51E2272FCD9600EC0531 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
@@ -230,7 +230,7 @@
 			children = (
 				4ACA51E8272FCDAE00EC0531 /* HomeView.swift */,
 				4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */,
-				4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */,
+				4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */,
 				4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */,
 			);
 			path = View;
@@ -637,7 +637,7 @@
 				87A555702728116400A9B5E3 /* HomeViewController.swift in Sources */,
 				4ACA5207272FCE5200EC0531 /* BusRouteModel.swift in Sources */,
 				4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */,
-				4A992C49273124AF0006FB8C /* FavoriteTableViewCell.swift in Sources */,
+				4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */,
 				87359B8B2730F0F000F461A7 /* SearchBusPushable.swift in Sources */,
 				873D639A27303B0500E79069 /* HomeCoornicator.swift in Sources */,
 				4ACA5201272FCE3100EC0531 /* SearchStationView.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		4A04682227327843008D87CE /* BusRoutePushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682127327843008D87CE /* BusRoutePushable.swift */; };
 		4A04682427327876008D87CE /* BusRouteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682327327876008D87CE /* BusRouteCoordinator.swift */; };
+		4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */; };
+		4A04682827327BEC008D87CE /* AlarmSettingPushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */; };
 		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
 		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
 		4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */; };
@@ -73,6 +75,8 @@
 /* Begin PBXFileReference section */
 		4A04682127327843008D87CE /* BusRoutePushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRoutePushable.swift; sourceTree = "<group>"; };
 		4A04682327327876008D87CE /* BusRouteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteCoordinator.swift; sourceTree = "<group>"; };
+		4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingCoordinator.swift; sourceTree = "<group>"; };
+		4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingPushable.swift; sourceTree = "<group>"; };
 		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
 		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
 		4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -212,6 +216,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA523A272FCF3C00EC0531 /* AlarmSettingViewController.swift */,
+				4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */,
 				4ACA521D272FCEA000EC0531 /* Model */,
 				4ACA521C272FCE9E00EC0531 /* UseCase */,
 				4ACA521B272FCE9A00EC0531 /* ViewModel */,
@@ -475,6 +480,7 @@
 				873D639727303A6800E79069 /* AppCoordinator.swift */,
 				4A04682127327843008D87CE /* BusRoutePushable.swift */,
 				87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */,
+				4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -657,10 +663,12 @@
 				4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */,
 				4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */,
 				4ACA5223272FCEB500EC0531 /* AlarmSettingViewModel.swift in Sources */,
+				4A04682827327BEC008D87CE /* AlarmSettingPushable.swift in Sources */,
 				4ACA5235272FCF2100EC0531 /* SearchStationViewController.swift in Sources */,
 				4A04682427327876008D87CE /* BusRouteCoordinator.swift in Sources */,
 				873D639C27303B5000E79069 /* SearchBusCoordinator.swift in Sources */,
 				4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */,
+				4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */,
 				4ACA522D272FCEDB00EC0531 /* MovingStatusUseCase.swift in Sources */,
 				4ACA5209272FCE5A00EC0531 /* BusRouteUseCase.swift in Sources */,
 				4ACA5233272FCF0F00EC0531 /* SearchBusViewController.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
+		4A992C49273124AF0006FB8C /* FavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */; };
+		4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */; };
 		4ACA51E3272FCD9600EC0531 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E2272FCD9600EC0531 /* HomeModel.swift */; };
 		4ACA51E5272FCD9C00EC0531 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */; };
 		4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E6272FCDA600EC0531 /* HomeViewModel.swift */; };
@@ -65,6 +68,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
+		4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
+		4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusCellTrailingView.swift; sourceTree = "<group>"; };
 		4ACA51E2272FCD9600EC0531 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
 		4ACA51E6272FCDA600EC0531 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -223,6 +229,9 @@
 			isa = PBXGroup;
 			children = (
 				4ACA51E8272FCDAE00EC0531 /* HomeView.swift */,
+				4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */,
+				4A992C48273124AF0006FB8C /* FavoriteTableViewCell.swift */,
+				4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -627,6 +636,8 @@
 				4ACA51F3272FCDF900EC0531 /* SearchBusViewModel.swift in Sources */,
 				87A555702728116400A9B5E3 /* HomeViewController.swift in Sources */,
 				4ACA5207272FCE5200EC0531 /* BusRouteModel.swift in Sources */,
+				4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */,
+				4A992C49273124AF0006FB8C /* FavoriteTableViewCell.swift in Sources */,
 				87359B8B2730F0F000F461A7 /* SearchBusPushable.swift in Sources */,
 				873D639A27303B0500E79069 /* HomeCoornicator.swift in Sources */,
 				4ACA5201272FCE3100EC0531 /* SearchStationView.swift in Sources */,
@@ -634,6 +645,7 @@
 				4ACA51FB272FCE1D00EC0531 /* SearchStationModel.swift in Sources */,
 				4ACA5213272FCE8500EC0531 /* StationModel.swift in Sources */,
 				4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */,
+				4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */,
 				4ACA5223272FCEB500EC0531 /* AlarmSettingViewModel.swift in Sources */,
 				4ACA5235272FCF2100EC0531 /* SearchStationViewController.swift in Sources */,
 				873D639C27303B5000E79069 /* SearchBusCoordinator.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */; };
 		4A04682827327BEC008D87CE /* AlarmSettingPushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */; };
 		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
+		4A1A22DD2732801700476861 /* StationCoodinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DC2732801700476861 /* StationCoodinator.swift */; };
+		4A1A22DF2732806300476861 /* StationPushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DE2732806300476861 /* StationPushable.swift */; };
 		4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */; };
 		4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */; };
 		4A992C4B273124D90006FB8C /* BusCellTrailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */; };
@@ -78,6 +80,8 @@
 		4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingCoordinator.swift; sourceTree = "<group>"; };
 		4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingPushable.swift; sourceTree = "<group>"; };
 		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
+		4A1A22DC2732801700476861 /* StationCoodinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationCoodinator.swift; sourceTree = "<group>"; };
+		4A1A22DE2732806300476861 /* StationPushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPushable.swift; sourceTree = "<group>"; };
 		4A992C4627311F1C0006FB8C /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
 		4A992C48273124AF0006FB8C /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A992C4A273124D90006FB8C /* BusCellTrailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusCellTrailingView.swift; sourceTree = "<group>"; };
@@ -204,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA5238272FCF3200EC0531 /* StationViewController.swift */,
+				4A1A22DC2732801700476861 /* StationCoodinator.swift */,
 				4ACA5211272FCE7100EC0531 /* Model */,
 				4ACA5210272FCE6E00EC0531 /* UseCase */,
 				4ACA520F272FCE6B00EC0531 /* ViewModel */,
@@ -481,6 +486,7 @@
 				4A04682127327843008D87CE /* BusRoutePushable.swift */,
 				87359B8A2730F0F000F461A7 /* SearchBusPushable.swift */,
 				4A04682727327BEC008D87CE /* AlarmSettingPushable.swift */,
+				4A1A22DE2732806300476861 /* StationPushable.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -646,12 +652,14 @@
 				4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */,
 				4ACA5225272FCEBF00EC0531 /* AlarmSettingView.swift in Sources */,
 				4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */,
+				4A1A22DD2732801700476861 /* StationCoodinator.swift in Sources */,
 				4ACA5237272FCF2C00EC0531 /* BusRouteViewController.swift in Sources */,
 				873D639827303A6800E79069 /* AppCoordinator.swift in Sources */,
 				4ACA5217272FCE8E00EC0531 /* StationViewModel.swift in Sources */,
 				4ACA51F3272FCDF900EC0531 /* SearchBusViewModel.swift in Sources */,
 				87A555702728116400A9B5E3 /* HomeViewController.swift in Sources */,
 				4ACA5207272FCE5200EC0531 /* BusRouteModel.swift in Sources */,
+				4A1A22DF2732806300476861 /* StationPushable.swift in Sources */,
 				4A992C4727311F1C0006FB8C /* FavoriteHeaderView.swift in Sources */,
 				4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */,
 				87359B8B2730F0F000F461A7 /* SearchBusPushable.swift in Sources */,

--- a/BBus/BBus.xcodeproj/xcshareddata/xcschemes/BBus.xcscheme
+++ b/BBus/BBus.xcodeproj/xcshareddata/xcschemes/BBus.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "87A555672728116400A9B5E3"
+               BuildableName = "BBus.app"
+               BlueprintName = "BBus"
+               ReferencedContainer = "container:BBus.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACA5241272FD52D00EC0531"
+               BuildableName = "BBusTests.xctest"
+               BlueprintName = "BBusTests"
+               ReferencedContainer = "container:BBus.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "87A555672728116400A9B5E3"
+            BuildableName = "BBus.app"
+            BlueprintName = "BBus"
+            ReferencedContainer = "container:BBus.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "87A555672728116400A9B5E3"
+            BuildableName = "BBus.app"
+            BlueprintName = "BBus"
+            ReferencedContainer = "container:BBus.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BBus/BBus/AlarmSetting/AlarmSettingCoordinator.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingCoordinator.swift
@@ -1,0 +1,29 @@
+//
+//  AlarmSettingCoordinator.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/03.
+//
+
+import UIKit
+
+class AlarmSettingCoordinator: NSObject, Coordinator {
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+        self.childCoordinators = []
+    }
+
+    func start() {
+        let viewController = AlarmSettingViewController()
+        viewController.coordinator = self
+        presenter.pushViewController(viewController, animated: true)
+    }
+
+    func terminate() {
+        self.coordinatorDidFinish()
+    }
+}

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -9,21 +9,18 @@ import UIKit
 
 class AlarmSettingViewController: UIViewController {
 
+    weak var coordinator: AlarmSettingCoordinator?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        self.view.backgroundColor = UIColor.green
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if self.isMovingFromParent {
+            self.coordinator?.terminate()
+        }
     }
-    */
 
 }

--- a/BBus/BBus/Assets.xcassets/bbusCongestionRed.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/bbusCongestionRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.337",
+          "green" : "0.435",
+          "red" : "0.875"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.337",
+          "green" : "0.435",
+          "red" : "0.875"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/bbusGray.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/bbusGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.745",
+          "red" : "0.745"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.745",
+          "red" : "0.745"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/bbusLightGray.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/bbusLightGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.969",
+          "red" : "0.969"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.969",
+          "red" : "0.969"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/bbusTypeBlue.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/bbusTypeBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.929",
+          "green" : "0.455",
+          "red" : "0.396"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.929",
+          "green" : "0.455",
+          "red" : "0.396"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/bbusTypeRed.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/bbusTypeRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.302",
+          "green" : "0.412",
+          "red" : "0.886"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.302",
+          "green" : "0.412",
+          "red" : "0.886"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Base.lproj/LaunchScreen.storyboard
+++ b/BBus/BBus/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,10 +14,10 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +25,9 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BBus/BBus/Base.lproj/LaunchScreen.storyboard
+++ b/BBus/BBus/Base.lproj/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
-        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,32 +16,6 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="qkt-VR-nJD">
-                                <rect key="frame" x="107" y="366" width="240" height="406"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="1" id="xQW-5U-eWN">
-                                    <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="30" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="10" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="jXq-ET-zX8">
-                                        <rect key="frame" x="56" y="10" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ISZ-f0-Vd3">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
-                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="tBx-ZY-SYB">
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </collectionReusableView>
-                            </collectionView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>

--- a/BBus/BBus/Base.lproj/LaunchScreen.storyboard
+++ b/BBus/BBus/Base.lproj/LaunchScreen.storyboard
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,13 +17,39 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="qkt-VR-nJD">
+                                <rect key="frame" x="107" y="366" width="240" height="406"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="1" id="xQW-5U-eWN">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="30" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="10" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="jXq-ET-zX8">
+                                        <rect key="frame" x="56" y="10" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ISZ-f0-Vd3">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="tBx-ZY-SYB">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </collectionReusableView>
+                            </collectionView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
     <resources>

--- a/BBus/BBus/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/BusRoute/BusRouteCoordinator.swift
@@ -1,0 +1,29 @@
+//
+//  BusRouteCoordinator.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/03.
+//
+
+import UIKit
+
+class BusRouteCoordinator: NSObject, Coordinator {
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+        self.childCoordinators = []
+    }
+
+    func start() {
+        let viewController = BusRouteViewController()
+        viewController.coordinator = self
+        presenter.pushViewController(viewController, animated: true)
+    }
+
+    func terminate() {
+        self.coordinatorDidFinish()
+    }
+}

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -14,7 +14,7 @@ class BusRouteViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = UIColor.systemBackground
+        self.view.backgroundColor = MyColor.white
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -9,21 +9,19 @@ import UIKit
 
 class BusRouteViewController: UIViewController {
 
+    weak var coordinator: BusRouteCoordinator?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        self.view.backgroundColor = UIColor.systemBackground
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if self.isMovingFromParent {
+            self.coordinator?.terminate()
+        }
     }
-    */
 
 }

--- a/BBus/BBus/Coordinator/AlarmSettingPushable.swift
+++ b/BBus/BBus/Coordinator/AlarmSettingPushable.swift
@@ -1,0 +1,21 @@
+//
+//  AlarmSettingPushable.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/03.
+//
+
+import Foundation
+
+protocol AlarmSettingPushable: Coordinator {
+    func pushToAlarmSetting()
+}
+
+extension AlarmSettingPushable {
+    func pushToAlarmSetting() {
+        let coordinator = AlarmSettingCoordinator(presenter: self.presenter)
+        coordinator.delegate = self
+        self.childCoordinators.append(coordinator)
+        coordinator.start()
+    }
+}

--- a/BBus/BBus/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Coordinator/AppCoordinator.swift
@@ -17,8 +17,8 @@ class AppCoordinator: NSObject, Coordinator {
         self.window = window
 
         let navigationController = UINavigationController()
+        navigationController.isNavigationBarHidden = true
         self.presenter = navigationController
-
         self.childCoordinators = []
     }
 

--- a/BBus/BBus/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Coordinator/AppCoordinator.swift
@@ -17,7 +17,6 @@ class AppCoordinator: NSObject, Coordinator {
         self.window = window
 
         let navigationController = UINavigationController()
-        navigationController.isNavigationBarHidden = true
         self.presenter = navigationController
 
         self.childCoordinators = []

--- a/BBus/BBus/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Coordinator/AppCoordinator.swift
@@ -17,6 +17,7 @@ class AppCoordinator: NSObject, Coordinator {
         self.window = window
 
         let navigationController = UINavigationController()
+        navigationController.isNavigationBarHidden = true
         self.presenter = navigationController
 
         self.childCoordinators = []

--- a/BBus/BBus/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Coordinator/AppCoordinator.swift
@@ -1,0 +1,35 @@
+//
+//  AppCoordinator.swift
+//  BBus
+//
+//  Created by Kang Minsang on 2021/11/02.
+//
+
+import UIKit
+
+class AppCoordinator: NSObject, Coordinator {
+    private let window: UIWindow
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(window: UIWindow) {
+        self.window = window
+
+        let navigationController = UINavigationController()
+        self.presenter = navigationController
+
+        self.childCoordinators = []
+    }
+
+    func start() {
+        self.window.rootViewController = self.presenter
+
+        let coordinator = HomeCoordinator(presenter: self.presenter)
+        coordinator.delegate = self
+        self.childCoordinators.append(coordinator)
+        coordinator.start()
+
+        self.window.makeKeyAndVisible()
+    }
+}

--- a/BBus/BBus/Coordinator/BusRoutePushable.swift
+++ b/BBus/BBus/Coordinator/BusRoutePushable.swift
@@ -1,0 +1,21 @@
+//
+//  BusRoutePushable.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/03.
+//
+
+import Foundation
+
+protocol BusRoutePushable: Coordinator {
+    func pushToBusRoute()
+}
+
+extension BusRoutePushable {
+    func pushToBusRoute() {
+        let coordinator = BusRouteCoordinator(presenter: self.presenter)
+        coordinator.delegate = self
+        self.childCoordinators.append(coordinator)
+        coordinator.start()
+    }
+}

--- a/BBus/BBus/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Coordinator/Coordinator.swift
@@ -1,0 +1,38 @@
+//
+//  Coordinator.swift
+//  BBus
+//
+//  Created by Kang Minsang on 2021/11/02.
+//
+
+import UIKit
+
+protocol CoordinatorFinishDelegate {
+    func coordinatorDidFinish()
+    func removeChildCoordinator(_ coordinator: Coordinator)
+}
+
+protocol Coordinator: AnyObject, CoordinatorFinishDelegate {
+    var delegate: CoordinatorFinishDelegate? { get set }
+    var presenter: UINavigationController { get set }
+    var childCoordinators: [Coordinator] { get set }
+    func start()
+}
+
+
+extension Coordinator {
+    func start() { }
+
+    func coordinatorDidFinish() {
+        self.delegate?.removeChildCoordinator(self)
+    }
+
+    func removeChildCoordinator(_ coordinator: Coordinator) {
+        for (index, child) in self.childCoordinators.enumerated() {
+            if coordinator === child {
+                self.childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/BBus/BBus/Coordinator/SearchBusPushable.swift
+++ b/BBus/BBus/Coordinator/SearchBusPushable.swift
@@ -1,0 +1,21 @@
+//
+//  SearchBusPushable.swift
+//  BBus
+//
+//  Created by Kang Minsang on 2021/11/02.
+//
+
+import Foundation
+
+protocol SearchBusPushable: Coordinator {
+    func pushToSearchBus()
+}
+
+extension SearchBusPushable {
+    func pushToSearchBus() {
+        let coordinator = SearchBusCoordinator(presenter: self.presenter)
+        coordinator.delegate = self
+        self.childCoordinators.append(coordinator)
+        coordinator.start()
+    }
+}

--- a/BBus/BBus/Coordinator/StationPushable.swift
+++ b/BBus/BBus/Coordinator/StationPushable.swift
@@ -1,0 +1,21 @@
+//
+//  StationPushable.swift
+//  BBus
+//
+//  Created by 이지수 on 2021/11/03.
+//
+
+import Foundation
+
+protocol StationPushable: Coordinator {
+    func pushToStation()
+}
+
+extension StationPushable {
+    func pushToStation() {
+        let coordinator = StationCoordinator(presenter: self.presenter)
+        coordinator.delegate = self
+        self.childCoordinators.append(coordinator)
+        coordinator.start()
+    }
+}

--- a/BBus/BBus/Home/HomeCoornicator.swift
+++ b/BBus/BBus/Home/HomeCoornicator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeCoordinator: SearchBusPushable, BusRoutePushable, AlarmSettingPushable {
+class HomeCoordinator: SearchBusPushable, BusRoutePushable, AlarmSettingPushable, StationPushable {
     var delegate: CoordinatorFinishDelegate?
     var presenter: UINavigationController
     var childCoordinators: [Coordinator]

--- a/BBus/BBus/Home/HomeCoornicator.swift
+++ b/BBus/BBus/Home/HomeCoornicator.swift
@@ -1,0 +1,28 @@
+//
+//  HomeCoornicator.swift
+//  BBus
+//
+//  Created by Kang Minsang on 2021/11/02.
+//
+
+import UIKit
+
+class HomeCoordinator: SearchBusPushable {
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+        self.childCoordinators = []
+    }
+
+    func start() {
+        let useCase = HomeUseCase()
+        let viewModel = HomeViewModel(useCase: useCase)
+        let viewController = HomeViewController(viewModel: viewModel)
+        viewController.coordinator = self
+        presenter.pushViewController(viewController, animated: false) // present
+    }
+}
+

--- a/BBus/BBus/Home/HomeCoornicator.swift
+++ b/BBus/BBus/Home/HomeCoornicator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeCoordinator: SearchBusPushable {
+class HomeCoordinator: SearchBusPushable, BusRoutePushable {
     var delegate: CoordinatorFinishDelegate?
     var presenter: UINavigationController
     var childCoordinators: [Coordinator]

--- a/BBus/BBus/Home/HomeCoornicator.swift
+++ b/BBus/BBus/Home/HomeCoornicator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeCoordinator: SearchBusPushable, BusRoutePushable {
+class HomeCoordinator: SearchBusPushable, BusRoutePushable, AlarmSettingPushable {
     var delegate: CoordinatorFinishDelegate?
     var presenter: UINavigationController
     var childCoordinators: [Coordinator]

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -32,6 +32,23 @@ class HomeViewController: UIViewController {
         self.homeView.configureLayout()
         self.homeView.configureReusableCell()
         self.homeView.configureDelegate(self)
+        
+        let app = UIApplication.shared
+        let statusBarHeight: CGFloat = app.statusBarFrame.size.height
+
+        let statusbarView = UIView()
+        statusbarView.backgroundColor = UIColor.white //컬러 설정 부분
+        self.view.addSubview(statusbarView)
+
+        statusbarView.translatesAutoresizingMaskIntoConstraints = false
+        statusbarView.heightAnchor
+            .constraint(equalToConstant: statusBarHeight).isActive = true
+        statusbarView.widthAnchor
+            .constraint(equalTo: self.view.widthAnchor, multiplier: 1.0).isActive = true
+        statusbarView.topAnchor
+            .constraint(equalTo: self.view.topAnchor).isActive = true
+        statusbarView.centerXAnchor
+            .constraint(equalTo: self.view.centerXAnchor).isActive = true
     }
 
     private func configureLayout() {
@@ -57,6 +74,7 @@ extension HomeViewController: UICollectionViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.contentOffset.y > 30 else { return }
         if (self.lastContentOffset > scrollView.contentOffset.y) {
             self.homeView.configureNavigationViewVisable(true)
         }
@@ -97,7 +115,16 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        CGSize(width: self.view.frame.width, height: 70)
+        if section == 0 {
+            return CGSize(width: self.view.frame.width, height: 120)
+        }
+        else {
+            return CGSize(width: self.view.frame.width, height: 70)
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 1, left: 0, bottom: 10, right: 0)
     }
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -41,6 +41,7 @@ class HomeViewController: UIViewController {
         self.configureLayout()
         self.homeView.configureLayout()
         self.addButtonAction()
+        self.homeView.configureDelegate(self)
     }
 
     private func configureLayout() {
@@ -68,3 +69,36 @@ class HomeViewController: UIViewController {
     }
 }
 
+extension HomeViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        5
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteTableViewCell.identifier, for: indexPath)
+                as? FavoriteTableViewCell else { return UITableViewCell() }
+
+        return cell
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        10
+    }
+}
+
+extension HomeViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: FavoriteHeaderView.identifier)
+                as? FavoriteHeaderView else { return UIView() }
+
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        90
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        90
+    }
+}

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -31,7 +31,6 @@ class HomeViewController: UIViewController {
         self.homeView.configureLayout()
         self.homeView.configureReusableCell()
         self.homeView.configureDelegate(self)
-//        self.addButtonAction()
     }
 
     private func configureLayout() {
@@ -46,12 +45,6 @@ class HomeViewController: UIViewController {
             self.homeView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
         ])
     }
-
-//    private func addButtonAction() {
-//        self.searchButton.addAction(UIAction.init(handler: { _ in
-//            self.coordinator?.pushToSearchBus()
-//        }), for: .touchUpInside)
-//    }
 }
 
 extension HomeViewController: UICollectionViewDelegate {
@@ -87,3 +80,10 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         CGSize(width: self.view.frame.width, height: 70)
     }
 }
+
+extension HomeViewController: HomeSearchButtonDelegate {
+    func shouldGoToSearchBusScene() {
+        self.coordinator?.pushToSearchBus()
+    }
+}
+

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -53,6 +53,8 @@ extension HomeViewController: UICollectionViewDelegate {
 
         self.coordinator?.pushToBusRoute()
     }
+    
+    
 }
 
 extension HomeViewController: UICollectionViewDataSource {
@@ -73,7 +75,9 @@ extension HomeViewController: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FavoriteHeaderView.identifier, for: indexPath)
+        guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FavoriteHeaderView.identifier, for: indexPath) as? FavoriteHeaderView else { return UICollectionReusableView() }
+        header.configureDelegate(self)
+        return header
     }
 }
 
@@ -98,5 +102,13 @@ extension HomeViewController: AlarmButtonDelegate {
         // TODO: Model binding Logic needed
 
         self.coordinator?.pushToAlarmSetting()
+    }
+}
+
+extension HomeViewController: FavoriteHeaderViewDelegate {
+    func shouldGoToStationScene() {
+        // TODO: Model binding Logic needed
+        
+        self.coordinator?.pushToStation()
     }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -48,6 +48,11 @@ class HomeViewController: UIViewController {
 }
 
 extension HomeViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // TODO: Model binding Logic needed
+
+        self.coordinator?.pushToBusRoute()
+    }
 }
 
 extension HomeViewController: UICollectionViewDataSource {

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -68,6 +68,7 @@ extension HomeViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FavoriteCollectionViewCell.identifier, for: indexPath)
                         as? FavoriteCollectionViewCell else { return UICollectionViewCell() }
 
+        cell.configureDelegate(self)
         return cell
     }
 
@@ -92,3 +93,10 @@ extension HomeViewController: HomeSearchButtonDelegate {
     }
 }
 
+extension HomeViewController: AlarmButtonDelegate {
+    func shouldGoToAlarmSettingScene() {
+        // TODO: Model binding Logic needed
+
+        self.coordinator?.pushToAlarmSetting()
+    }
+}

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -69,44 +69,20 @@ class HomeViewController: UIViewController {
     }
 }
 
-extension HomeViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+extension HomeViewController: UICollectionViewDelegate {
+
+}
+
+extension HomeViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         5
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteTableViewCell.identifier, for: indexPath)
-                as? FavoriteTableViewCell else { return UITableViewCell() }
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FavoriteCollectionViewCell.identifier, for: indexPath)
+                        as? FavoriteCollectionViewCell else { return UICollectionViewCell() }
 
         return cell
     }
 
-    func numberOfSections(in tableView: UITableView) -> Int {
-        10
-    }
-}
-
-extension HomeViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: FavoriteHeaderView.identifier)
-                as? FavoriteHeaderView else { return UIView() }
-
-        return header
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        70
-    }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        70
-    }
-    
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        13
-    }
-    
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return UIView()
-    }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -48,7 +48,7 @@ class HomeViewController: UIViewController {
         self.view.backgroundColor = UIColor.systemBackground
 
         self.searchButton.translatesAutoresizingMaskIntoConstraints = false
-        self.searchButton.widthAnchor.constraint(equalToConstant: self.view.frame.width).isActive = true
+        self.searchButton.widthAnchor.constraint(equalToConstant: self.view.frame.width - 20).isActive = true
         self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
         self.navigationItem.titleView = self.searchButton
 
@@ -100,5 +100,13 @@ extension HomeViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         70
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        13
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
     }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class HomeViewController: UIViewController {
 
+    weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
     private lazy var homeView = HomeView()
 
@@ -24,13 +25,16 @@ class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.title = "Home"
 
         self.configureLayout()
         self.homeView.configureLayout()
+        self.homeView.showAlwaysButton()
+        self.addButtonAction()
     }
 
     private func configureLayout() {
-        self.view.backgroundColor = UIColor.yellow
+        self.view.backgroundColor = UIColor.lightGray
         self.homeView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.homeView)
         NSLayoutConstraint.activate([
@@ -41,5 +45,12 @@ class HomeViewController: UIViewController {
         ])
     }
 
+    private func addButtonAction() {
+        self.homeView.refreshButton.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
+    }
+
+    @objc func buttonAction(_ sender: UIButton) {
+        coordinator?.pushToSearchBus()
+    }
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -71,12 +71,11 @@ class HomeViewController: UIViewController {
 }
 
 extension HomeViewController: UICollectionViewDelegate {
-
 }
 
 extension HomeViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        1
+        5
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -90,10 +89,17 @@ extension HomeViewController: UICollectionViewDataSource {
         return cell
     }
 
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FavoriteHeaderView.identifier, for: indexPath)
+    }
 }
 
 extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        CGSize(width: self.view.frame.width, height: 70)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         CGSize(width: self.view.frame.width, height: 70)
     }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -9,10 +9,37 @@ import UIKit
 
 class HomeViewController: UIViewController {
 
+    private let viewModel: HomeViewModel?
+    private lazy var homeView = HomeView()
+
+    init(viewModel: HomeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.viewModel = nil
+        super.init(coder: coder)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = UIColor.systemBackground
+        self.configureLayout()
+        self.homeView.configureLayout()
     }
+
+    private func configureLayout() {
+        self.view.backgroundColor = UIColor.yellow
+        self.homeView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.homeView)
+        NSLayoutConstraint.activate([
+            self.homeView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.homeView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            self.homeView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            self.homeView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -40,8 +40,9 @@ class HomeViewController: UIViewController {
 
         self.configureLayout()
         self.homeView.configureLayout()
-        self.addButtonAction()
+        self.homeView.configureReusableCell()
         self.homeView.configureDelegate(self)
+        self.addButtonAction()
     }
 
     private func configureLayout() {
@@ -74,6 +75,10 @@ extension HomeViewController: UICollectionViewDelegate {
 }
 
 extension HomeViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        1
+    }
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         5
     }
@@ -85,4 +90,10 @@ extension HomeViewController: UICollectionViewDataSource {
         return cell
     }
 
+}
+
+extension HomeViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        CGSize(width: self.view.frame.width, height: 70)
+    }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -12,7 +12,7 @@ class HomeViewController: UIViewController {
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
     private lazy var searchButton: UIButton = {
-        let button = UIButton(frame: CGRect(origin: CGPoint(), size: CGSize(width: self.view.frame.width, height: 30)))
+        let button = UIButton()
         button.backgroundColor = UIColor(named: "bbusLightGray")
         button.layer.borderColor = UIColor(named: "bbusGray")?.cgColor
         button.layer.borderWidth = 0.3
@@ -46,9 +46,10 @@ class HomeViewController: UIViewController {
     private func configureLayout() {
         self.view.backgroundColor = UIColor.systemBackground
 
-        self.navigationItem.titleView = self.searchButton
+        self.searchButton.translatesAutoresizingMaskIntoConstraints = false
+        self.searchButton.widthAnchor.constraint(equalToConstant: self.view.frame.width).isActive = true
         self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
-
+        self.navigationItem.titleView = self.searchButton
 
         self.homeView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.homeView)
@@ -61,11 +62,9 @@ class HomeViewController: UIViewController {
     }
 
     private func addButtonAction() {
-        self.homeView.refreshButton.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
-    }
-
-    @objc func buttonAction(_ sender: UIButton) {
-        coordinator?.pushToSearchBus()
+        self.searchButton.addAction(UIAction.init(handler: { _ in
+            self.coordinator?.pushToSearchBus()
+        }), for: .touchUpInside)
     }
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -12,6 +12,7 @@ class HomeViewController: UIViewController {
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
     private lazy var homeView = HomeView()
+    private var lastContentOffset: CGFloat = 0
 
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -48,13 +49,22 @@ class HomeViewController: UIViewController {
 }
 
 extension HomeViewController: UICollectionViewDelegate {
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: Model binding Logic needed
 
         self.coordinator?.pushToBusRoute()
     }
     
-    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if (self.lastContentOffset > scrollView.contentOffset.y) {
+            self.homeView.configureNavigationViewVisable(true)
+        }
+        else if (self.lastContentOffset < scrollView.contentOffset.y) {
+            self.homeView.configureNavigationViewVisable(false)
+        }
+        self.lastContentOffset = scrollView.contentOffset.y
+    }
 }
 
 extension HomeViewController: UICollectionViewDataSource {

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -7,8 +7,30 @@
 
 import UIKit
 
-class HomeViewController: UIViewController {
+enum MyColor {
+    static let white = UIColor.white
+    static let clear = UIColor.clear
+    static let blueBus = UIColor.systemBlue
+    static let systemGray6 = UIColor.systemGray6
+    static let bbusLightGray = UIColor(named: "bbusLightGray")
+    static let bbusGray = UIColor(named: "bbusGray")
+    static let bbusTypeBlue = UIColor(named: "bbusTypeBlue")
+    static let bbusCongestionRed = UIColor(named: "bbusCongestionRed")
+}
 
+enum MyImage {
+    static let refresh: UIImage? = {
+        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
+        return UIImage(systemName: "arrow.triangle.2.circlepath", withConfiguration: largeConfig)
+    }()
+    static let alarm: UIImage? = {
+        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
+        return UIImage(systemName: "alarm", withConfiguration: largeConfig)
+    }()
+}
+
+class HomeViewController: UIViewController {
+    
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
     private lazy var homeView = HomeView()
@@ -30,7 +52,6 @@ class HomeViewController: UIViewController {
 
         self.configureLayout()
         self.homeView.configureLayout()
-        self.homeView.configureReusableCell()
         self.homeView.configureDelegate(self)
         
         let app = UIApplication.shared
@@ -39,7 +60,6 @@ class HomeViewController: UIViewController {
         let statusbarView = UIView()
         statusbarView.backgroundColor = UIColor.white //컬러 설정 부분
         self.view.addSubview(statusbarView)
-
         statusbarView.translatesAutoresizingMaskIntoConstraints = false
         statusbarView.heightAnchor
             .constraint(equalToConstant: statusBarHeight).isActive = true
@@ -51,11 +71,12 @@ class HomeViewController: UIViewController {
             .constraint(equalTo: self.view.centerXAnchor).isActive = true
     }
 
+    // MARK: - Configuration
     private func configureLayout() {
         self.view.backgroundColor = UIColor.systemBackground
 
-        self.homeView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.homeView)
+        self.homeView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.homeView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             self.homeView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
@@ -65,6 +86,7 @@ class HomeViewController: UIViewController {
     }
 }
 
+// MARK: - Delegate : UICollectionView
 extension HomeViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -85,13 +107,14 @@ extension HomeViewController: UICollectionViewDelegate {
     }
 }
 
+// MARK: - DataSource : UICollectionView
 extension HomeViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        5
+        return 5
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        5
+        return 5
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -109,9 +132,10 @@ extension HomeViewController: UICollectionViewDataSource {
     }
 }
 
+// MARK: - DelegateFlowLayout : UICollectionView
 extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        CGSize(width: self.view.frame.width, height: 70)
+        return CGSize(width: self.view.frame.width, height: 70)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -128,12 +152,14 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
+// MARK: - HomeSearchButtonDelegate : UICollectionView
 extension HomeViewController: HomeSearchButtonDelegate {
     func shouldGoToSearchBusScene() {
         self.coordinator?.pushToSearchBus()
     }
 }
 
+// MARK: - AlarmButtonDelegate : UICollectionView
 extension HomeViewController: AlarmButtonDelegate {
     func shouldGoToAlarmSettingScene() {
         // TODO: Model binding Logic needed
@@ -142,6 +168,7 @@ extension HomeViewController: AlarmButtonDelegate {
     }
 }
 
+// MARK: - FavoriteHeaderViewDelegate : UICollectionView
 extension HomeViewController: FavoriteHeaderViewDelegate {
     func shouldGoToStationScene() {
         // TODO: Model binding Logic needed

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -95,10 +95,10 @@ extension HomeViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        90
+        70
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        90
+        70
     }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 enum MyColor {
+    static let gray = UIColor.gray
     static let white = UIColor.white
     static let clear = UIColor.clear
     static let blueBus = UIColor.systemBlue
@@ -96,7 +97,9 @@ extension HomeViewController: UICollectionViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard scrollView.contentOffset.y > 30 else { return }
+        let minimumScrollOffset = HomeNavigationView.height - 20
+
+        guard scrollView.contentOffset.y > minimumScrollOffset else { return }
         if (self.lastContentOffset > scrollView.contentOffset.y) {
             self.homeView.configureNavigationViewVisable(true)
         }
@@ -135,20 +138,16 @@ extension HomeViewController: UICollectionViewDataSource {
 // MARK: - DelegateFlowLayout : UICollectionView
 extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: self.view.frame.width, height: 70)
+        return CGSize(width: self.view.frame.width, height: FavoriteCollectionViewCell.height)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         if section == 0 {
-            return CGSize(width: self.view.frame.width, height: 120)
+            return CGSize(width: self.view.frame.width, height: FavoriteHeaderView.height + HomeNavigationView.height)
         }
         else {
-            return CGSize(width: self.view.frame.width, height: 70)
+            return CGSize(width: self.view.frame.width, height: FavoriteHeaderView.height)
         }
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 1, left: 0, bottom: 10, right: 0)
     }
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -11,17 +11,6 @@ class HomeViewController: UIViewController {
 
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
-    private lazy var searchButton: UIButton = {
-        let button = UIButton()
-        button.backgroundColor = UIColor(named: "bbusLightGray")
-        button.layer.borderColor = UIColor(named: "bbusGray")?.cgColor
-        button.layer.borderWidth = 0.3
-        button.layer.cornerRadius = 3
-        button.setTitle("버스 또는 정류장 검색", for: .normal)
-        button.setTitleColor(UIColor(named: "bbusGray"), for: .normal)
-        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
-        return button
-    }()
     private lazy var homeView = HomeView()
 
     init(viewModel: HomeViewModel) {
@@ -42,16 +31,11 @@ class HomeViewController: UIViewController {
         self.homeView.configureLayout()
         self.homeView.configureReusableCell()
         self.homeView.configureDelegate(self)
-        self.addButtonAction()
+//        self.addButtonAction()
     }
 
     private func configureLayout() {
         self.view.backgroundColor = UIColor.systemBackground
-
-        self.searchButton.translatesAutoresizingMaskIntoConstraints = false
-        self.searchButton.widthAnchor.constraint(equalToConstant: self.view.frame.width - 20).isActive = true
-        self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
-        self.navigationItem.titleView = self.searchButton
 
         self.homeView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.homeView)
@@ -63,11 +47,11 @@ class HomeViewController: UIViewController {
         ])
     }
 
-    private func addButtonAction() {
-        self.searchButton.addAction(UIAction.init(handler: { _ in
-            self.coordinator?.pushToSearchBus()
-        }), for: .touchUpInside)
-    }
+//    private func addButtonAction() {
+//        self.searchButton.addAction(UIAction.init(handler: { _ in
+//            self.coordinator?.pushToSearchBus()
+//        }), for: .touchUpInside)
+//    }
 }
 
 extension HomeViewController: UICollectionViewDelegate {

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -13,8 +13,13 @@ class HomeViewController: UIViewController {
     private let viewModel: HomeViewModel?
     private lazy var searchButton: UIButton = {
         let button = UIButton(frame: CGRect(origin: CGPoint(), size: CGSize(width: self.view.frame.width, height: 30)))
-        button.backgroundColor = .gray
+        button.backgroundColor = UIColor(named: "bbusLightGray")
+        button.layer.borderColor = UIColor(named: "bbusGray")?.cgColor
+        button.layer.borderWidth = 0.3
+        button.layer.cornerRadius = 3
         button.setTitle("버스 또는 정류장 검색", for: .normal)
+        button.setTitleColor(UIColor(named: "bbusGray"), for: .normal)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
         return button
     }()
     private lazy var homeView = HomeView()
@@ -39,7 +44,7 @@ class HomeViewController: UIViewController {
     }
 
     private func configureLayout() {
-        self.view.backgroundColor = UIColor.lightGray
+        self.view.backgroundColor = UIColor.systemBackground
 
         self.navigationItem.titleView = self.searchButton
         self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -11,6 +11,12 @@ class HomeViewController: UIViewController {
 
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
+    private lazy var searchButton: UIButton = {
+        let button = UIButton(frame: CGRect(origin: CGPoint(), size: CGSize(width: self.view.frame.width, height: 30)))
+        button.backgroundColor = .gray
+        button.setTitle("버스 또는 정류장 검색", for: .normal)
+        return button
+    }()
     private lazy var homeView = HomeView()
 
     init(viewModel: HomeViewModel) {
@@ -29,12 +35,16 @@ class HomeViewController: UIViewController {
 
         self.configureLayout()
         self.homeView.configureLayout()
-        self.homeView.showAlwaysButton()
         self.addButtonAction()
     }
 
     private func configureLayout() {
         self.view.backgroundColor = UIColor.lightGray
+
+        self.navigationItem.titleView = self.searchButton
+        self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
+
+
         self.homeView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.homeView)
         NSLayoutConstraint.activate([

--- a/BBus/BBus/Home/Model/HomeModel.swift
+++ b/BBus/BBus/Home/Model/HomeModel.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct HomeModel {
+    
+}

--- a/BBus/BBus/Home/UseCase/HomeUseCase.swift
+++ b/BBus/BBus/Home/UseCase/HomeUseCase.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+struct HomeUseCase {
+
+    private let homeModel: HomeModel
+
+    init() {
+        self.homeModel = HomeModel()
+    }
+}

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -36,16 +36,16 @@ class BusCellTrailingView: UIView {
     }()
     private lazy var firstBusTimeRightLabel: UILabel = {
         let label = UILabel()
-        label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
+        label.layer.borderColor = MyColor.bbusLightGray?.cgColor
         label.layer.borderWidth = 2
         label.layer.cornerRadius = 3
         label.font = UIFont.systemFont(ofSize: 11)
-        label.textColor = UIColor(named: "bbusGray")
+        label.textColor = MyColor.bbusGray
         label.attributedText = NSAttributedString()
         let fullText = "2번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
         let attributedString = NSMutableAttributedString(string: fullText)
-        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed") as Any, range: range)
+        attributedString.addAttribute(.foregroundColor, value: MyColor.bbusCongestionRed as Any, range: range)
         label.attributedText = attributedString
         label.sizeToFit()
         label.textAlignment = .center
@@ -53,16 +53,16 @@ class BusCellTrailingView: UIView {
     }()
     private lazy var secondBusTimeRightLabel: UILabel = {
         let label = UILabel()
-        label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
+        label.layer.borderColor = MyColor.bbusLightGray?.cgColor
         label.layer.borderWidth = 2
         label.layer.cornerRadius = 3
         label.font = UIFont.systemFont(ofSize: 11)
-        label.textColor = UIColor(named: "bbusGray")
+        label.textColor = MyColor.bbusGray
         label.attributedText = NSAttributedString()
         let fullText = "6번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
         let attributedString = NSMutableAttributedString(string: fullText)
-        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed") as Any, range: range)
+        attributedString.addAttribute(.foregroundColor, value: MyColor.bbusCongestionRed as Any, range: range)
         label.attributedText = attributedString
         label.sizeToFit()
         label.textAlignment = .center
@@ -70,12 +70,12 @@ class BusCellTrailingView: UIView {
     }()
     private lazy var alarmButton: UIButton = {
         let button = UIButton()
-        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
-        button.setImage(UIImage(systemName: "alarm", withConfiguration: largeConfig), for: .normal)
-        button.tintColor = UIColor(named: "bbusGray")
+        button.setImage(MyImage.alarm, for: .normal)
+        button.tintColor = MyColor.bbusGray
         return button
     }()
 
+    // MARK: - Configuration
     func configureLayout() {
         self.addSubview(self.firstBusTimeLabel)
         self.firstBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -24,9 +24,10 @@ class BusCellTrailingView: UIView {
     private lazy var firstBusTimeRightLabel: UILabel = {
         let label = UILabel()
         label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
-        label.layer.borderWidth = 0.2
+        label.layer.borderWidth = 2
         label.layer.cornerRadius = 2
-        label.font = UIFont.boldSystemFont(ofSize: 10)
+        label.font = UIFont.systemFont(ofSize: 11)
+        label.textColor = UIColor(named: "bbusGray")
         label.attributedText = NSAttributedString()
         let fullText = "2번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
@@ -38,9 +39,10 @@ class BusCellTrailingView: UIView {
     private lazy var secondBusTimeRightLabel: UILabel = {
         let label = UILabel()
         label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
-        label.layer.borderWidth = 0.2
+        label.layer.borderWidth = 2
         label.layer.cornerRadius = 2
-        label.font = UIFont.boldSystemFont(ofSize: 10)
+        label.font = UIFont.systemFont(ofSize: 11)
+        label.textColor = UIColor(named: "bbusGray")
         label.attributedText = NSAttributedString()
         let fullText = "6번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
@@ -51,7 +53,8 @@ class BusCellTrailingView: UIView {
     }()
     private lazy var alarmButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "alarm"), for: .normal)
+        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
+        button.setImage(UIImage(systemName: "alarm", withConfiguration: largeConfig), for: .normal)
         button.tintColor = UIColor(named: "bbusGray")
         return button
     }()
@@ -60,14 +63,14 @@ class BusCellTrailingView: UIView {
         self.addSubview(self.firstBusTimeLabel)
         self.firstBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.firstBusTimeLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
+            self.firstBusTimeLabel.bottomAnchor.constraint(equalTo: self.centerYAnchor, constant: -3),
             self.firstBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
         ])
 
         self.addSubview(self.secondBusTimeLabel)
         self.secondBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.secondBusTimeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10),
+            self.secondBusTimeLabel.topAnchor.constraint(equalTo: self.centerYAnchor, constant: 3),
             self.secondBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
         ])
 
@@ -88,10 +91,10 @@ class BusCellTrailingView: UIView {
         self.addSubview(self.alarmButton)
         self.alarmButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.alarmButton.widthAnchor.constraint(equalToConstant: 50),
+            self.alarmButton.widthAnchor.constraint(equalToConstant: 20),
             self.alarmButton.heightAnchor.constraint(equalTo: self.alarmButton.widthAnchor),
             self.alarmButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 20)
+            self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20)
         ])
     }
 }

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -1,0 +1,97 @@
+//
+//  BusCellTrailingView.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/02.
+//
+
+import UIKit
+
+class BusCellTrailingView: UIView {
+
+    private lazy var firstBusTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.text = "1분 29초"
+        return label
+    }()
+    private lazy var secondBusTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.text = "9분 51초"
+        return label
+    }()
+    private lazy var firstBusTimeRightLabel: UILabel = {
+        let label = UILabel()
+        label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
+        label.layer.borderWidth = 0.2
+        label.layer.cornerRadius = 2
+        label.font = UIFont.boldSystemFont(ofSize: 10)
+        label.attributedText = NSAttributedString()
+        let fullText = "2번째전 여유"
+        let range = (fullText as NSString).range(of: "여유")
+        let attributedString = NSMutableAttributedString(string: fullText)
+        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed"), range: range)
+        label.attributedText = attributedString
+        return label
+    }()
+    private lazy var secondBusTimeRightLabel: UILabel = {
+        let label = UILabel()
+        label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
+        label.layer.borderWidth = 0.2
+        label.layer.cornerRadius = 2
+        label.font = UIFont.boldSystemFont(ofSize: 10)
+        label.attributedText = NSAttributedString()
+        let fullText = "6번째전 여유"
+        let range = (fullText as NSString).range(of: "여유")
+        let attributedString = NSMutableAttributedString(string: fullText)
+        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed"), range: range)
+        label.attributedText = attributedString
+        return label
+    }()
+    private lazy var alarmButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(named: "alarm"), for: .normal)
+        button.tintColor = UIColor(named: "bbusGray")
+        return button
+    }()
+
+    func configureLayout() {
+        self.addSubview(self.firstBusTimeLabel)
+        self.firstBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.firstBusTimeLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
+            self.firstBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+        ])
+
+        self.addSubview(self.secondBusTimeLabel)
+        self.secondBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.secondBusTimeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10),
+            self.secondBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+        ])
+
+        self.addSubview(self.firstBusTimeRightLabel)
+        self.firstBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.firstBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.firstBusTimeLabel.centerYAnchor),
+            self.firstBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.firstBusTimeLabel.trailingAnchor, constant: 4)
+        ])
+
+        self.addSubview(self.secondBusTimeRightLabel)
+        self.secondBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.secondBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.secondBusTimeLabel.centerYAnchor),
+            self.secondBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.secondBusTimeLabel.trailingAnchor, constant: 4)
+        ])
+
+        self.addSubview(self.alarmButton)
+        self.alarmButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.alarmButton.widthAnchor.constraint(equalToConstant: 50),
+            self.alarmButton.heightAnchor.constraint(equalTo: self.alarmButton.widthAnchor),
+            self.alarmButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 20)
+        ])
+    }
+}

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -15,12 +15,13 @@ class BusCellTrailingView: UIView {
 
     private var alarmButtonDelegate: AlarmButtonDelegate? {
         didSet {
-            self.alarmButton.addAction(UIAction(handler: { _ in
+            let action = UIAction(handler: {_ in
                 self.alarmButtonDelegate?.shouldGoToAlarmSettingScene()
-            }), for: .touchUpInside)
+            })
+            self.alarmButton.removeTarget(nil, action: nil, for: .allEvents)
+            self.alarmButton.addAction(action, for: .touchUpInside)
         }
     }
-
     private lazy var firstBusTimeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.boldSystemFont(ofSize: 14)

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -25,30 +25,34 @@ class BusCellTrailingView: UIView {
         let label = UILabel()
         label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
         label.layer.borderWidth = 2
-        label.layer.cornerRadius = 2
+        label.layer.cornerRadius = 3
         label.font = UIFont.systemFont(ofSize: 11)
         label.textColor = UIColor(named: "bbusGray")
         label.attributedText = NSAttributedString()
         let fullText = "2번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
         let attributedString = NSMutableAttributedString(string: fullText)
-        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed"), range: range)
+        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed") as Any, range: range)
         label.attributedText = attributedString
+        label.sizeToFit()
+        label.textAlignment = .center
         return label
     }()
     private lazy var secondBusTimeRightLabel: UILabel = {
         let label = UILabel()
         label.layer.borderColor = UIColor(named: "bbusLightGray")?.cgColor
         label.layer.borderWidth = 2
-        label.layer.cornerRadius = 2
+        label.layer.cornerRadius = 3
         label.font = UIFont.systemFont(ofSize: 11)
         label.textColor = UIColor(named: "bbusGray")
         label.attributedText = NSAttributedString()
         let fullText = "6번째전 여유"
         let range = (fullText as NSString).range(of: "여유")
         let attributedString = NSMutableAttributedString(string: fullText)
-        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed"), range: range)
+        attributedString.addAttribute(.foregroundColor, value: UIColor(named: "bbusCongestionRed") as Any, range: range)
         label.attributedText = attributedString
+        label.sizeToFit()
+        label.textAlignment = .center
         return label
     }()
     private lazy var alarmButton: UIButton = {
@@ -78,14 +82,18 @@ class BusCellTrailingView: UIView {
         self.firstBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.firstBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.firstBusTimeLabel.centerYAnchor),
-            self.firstBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.firstBusTimeLabel.trailingAnchor, constant: 4)
+            self.firstBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.firstBusTimeLabel.trailingAnchor, constant: 4),
+            self.firstBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.width + 10),
+            self.firstBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.height + 5)
         ])
 
         self.addSubview(self.secondBusTimeRightLabel)
         self.secondBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.secondBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.secondBusTimeLabel.centerYAnchor),
-            self.secondBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.secondBusTimeLabel.trailingAnchor, constant: 4)
+            self.secondBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.secondBusTimeLabel.trailingAnchor, constant: 4),
+            self.secondBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.width + 10),
+            self.secondBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.height + 5)
         ])
 
         self.addSubview(self.alarmButton)

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -77,45 +77,52 @@ class BusCellTrailingView: UIView {
 
     // MARK: - Configuration
     func configureLayout() {
+        let centerYInterval: CGFloat = 3
+
         self.addSubview(self.firstBusTimeLabel)
         self.firstBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.firstBusTimeLabel.bottomAnchor.constraint(equalTo: self.centerYAnchor, constant: -3),
+            self.firstBusTimeLabel.bottomAnchor.constraint(equalTo: self.centerYAnchor, constant: -centerYInterval),
             self.firstBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
         ])
 
         self.addSubview(self.secondBusTimeLabel)
         self.secondBusTimeLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.secondBusTimeLabel.topAnchor.constraint(equalTo: self.centerYAnchor, constant: 3),
+            self.secondBusTimeLabel.topAnchor.constraint(equalTo: self.centerYAnchor, constant: centerYInterval),
             self.secondBusTimeLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor)
         ])
 
+        let trailingViewLabelsInterval: CGFloat = 4
+        let rightLabelWidthPadding: CGFloat = 10
+        let rightLabelHeightPadding: CGFloat = 5
         self.addSubview(self.firstBusTimeRightLabel)
         self.firstBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.firstBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.firstBusTimeLabel.centerYAnchor),
-            self.firstBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.firstBusTimeLabel.trailingAnchor, constant: 4),
-            self.firstBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.width + 10),
-            self.firstBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.height + 5)
+            self.firstBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.firstBusTimeLabel.trailingAnchor, constant: trailingViewLabelsInterval),
+            self.firstBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.width + rightLabelWidthPadding),
+            self.firstBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.firstBusTimeRightLabel.frame.height + rightLabelHeightPadding)
         ])
 
         self.addSubview(self.secondBusTimeRightLabel)
         self.secondBusTimeRightLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.secondBusTimeRightLabel.centerYAnchor.constraint(equalTo: self.secondBusTimeLabel.centerYAnchor),
-            self.secondBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.secondBusTimeLabel.trailingAnchor, constant: 4),
-            self.secondBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.width + 10),
-            self.secondBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.height + 5)
+            self.secondBusTimeRightLabel.leadingAnchor.constraint(equalTo: self.secondBusTimeLabel.trailingAnchor, constant: trailingViewLabelsInterval),
+            self.secondBusTimeRightLabel.widthAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.width + rightLabelWidthPadding),
+            self.secondBusTimeRightLabel.heightAnchor.constraint(equalToConstant: self.secondBusTimeRightLabel.frame.height + rightLabelHeightPadding)
         ])
 
+        let alarmButtonWidth: CGFloat = 20
+        let alarmButtonTrailingInterval: CGFloat = -20
         self.addSubview(self.alarmButton)
         self.alarmButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.alarmButton.widthAnchor.constraint(equalToConstant: 20),
+            self.alarmButton.widthAnchor.constraint(equalToConstant: alarmButtonWidth),
             self.alarmButton.heightAnchor.constraint(equalTo: self.alarmButton.widthAnchor),
             self.alarmButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20)
+            self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: alarmButtonTrailingInterval)
         ])
     }
 

--- a/BBus/BBus/Home/View/BusCellTrailingView.swift
+++ b/BBus/BBus/Home/View/BusCellTrailingView.swift
@@ -7,7 +7,19 @@
 
 import UIKit
 
+protocol AlarmButtonDelegate {
+    func shouldGoToAlarmSettingScene()
+}
+
 class BusCellTrailingView: UIView {
+
+    private var alarmButtonDelegate: AlarmButtonDelegate? {
+        didSet {
+            self.alarmButton.addAction(UIAction(handler: { _ in
+                self.alarmButtonDelegate?.shouldGoToAlarmSettingScene()
+            }), for: .touchUpInside)
+        }
+    }
 
     private lazy var firstBusTimeLabel: UILabel = {
         let label = UILabel()
@@ -104,5 +116,9 @@ class BusCellTrailingView: UIView {
             self.alarmButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             self.alarmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20)
         ])
+    }
+
+    func configureDelegate(_ delegate: AlarmButtonDelegate) {
+        self.alarmButtonDelegate = delegate
     }
 }

--- a/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
@@ -15,7 +15,7 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.text = "272"
         label.font = UIFont.boldSystemFont(ofSize: 22)
-        label.textColor = UIColor(named: "bbusTypeBlue")
+        label.textColor = MyColor.bbusTypeBlue
         return label
     }()
     private lazy var trailingView = BusCellTrailingView()
@@ -34,6 +34,7 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
         self.configureUI()
     }
 
+    // MARK: - Configuration
     private func configureLayout() {
         self.addSubview(self.busNumberLabel)
         self.busNumberLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -57,6 +58,6 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
     }
 
     private func configureUI() {
-        self.backgroundColor = UIColor.systemBackground
+        self.backgroundColor = MyColor.white
     }
 }

--- a/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
@@ -24,12 +24,14 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
         self.trailingView.configureLayout()
         self.configureLayout()
+        self.configureUI()
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.trailingView.configureLayout()
         self.configureLayout()
+        self.configureUI()
     }
 
     private func configureLayout() {
@@ -48,5 +50,9 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
             self.trailingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.trailingView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5)
         ])
+    }
+
+    private func configureUI() {
+        self.backgroundColor = UIColor.systemBackground
     }
 }

--- a/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-class FavoriteTableViewCell: UITableViewCell {
+class FavoriteCollectionViewCell: UICollectionViewCell {
 
-    static let identifier = "FavoriteTableViewCell"
+    static let identifier = "FavoriteCollectionViewCell"
 
     private lazy var busNumberLabel: UILabel = {
         let label = UILabel()
@@ -20,14 +20,14 @@ class FavoriteTableViewCell: UITableViewCell {
     }()
     private lazy var trailingView = BusCellTrailingView()
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
         self.trailingView.configureLayout()
         self.configureLayout()
     }
 
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         self.trailingView.configureLayout()
         self.configureLayout()
     }

--- a/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
@@ -52,6 +52,10 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
         ])
     }
 
+    func configureDelegate(_ delegate: AlarmButtonDelegate) {
+        self.trailingView.configureDelegate(delegate)
+    }
+
     private func configureUI() {
         self.backgroundColor = UIColor.systemBackground
     }

--- a/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionViewCell.swift
@@ -10,6 +10,7 @@ import UIKit
 class FavoriteCollectionViewCell: UICollectionViewCell {
 
     static let identifier = "FavoriteCollectionViewCell"
+    static let height: CGFloat = 70
 
     private lazy var busNumberLabel: UILabel = {
         let label = UILabel()
@@ -36,11 +37,14 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
 
     // MARK: - Configuration
     private func configureLayout() {
+        let leadingInterval: CGFloat = 20
+        let half: CGFloat = 0.5
+
         self.addSubview(self.busNumberLabel)
         self.busNumberLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.busNumberLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            self.busNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20)
+            self.busNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leadingInterval)
         ])
 
         self.addSubview(self.trailingView)
@@ -49,7 +53,7 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
             self.trailingView.topAnchor.constraint(equalTo: self.topAnchor),
             self.trailingView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.trailingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.trailingView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5)
+            self.trailingView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: half)
         ])
     }
 

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -1,0 +1,57 @@
+//
+//  FavoriteHeader.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/02.
+//
+
+import UIKit
+
+class FavoriteHeaderView: UITableViewHeaderFooterView {
+
+    static let identifier = "FavoriteHeaderView"
+
+    private lazy var stationTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "여의도환승센터(4번승강장)"
+        label.font = UIFont.boldSystemFont(ofSize: 20)
+        return label
+    }()
+    private lazy var directionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "여의도 공원 방면"
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.textColor = UIColor(named: "bbusGray")
+        return label
+    }()
+
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        self.configureLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureLayout()
+    }
+
+    private func configureLayout() {
+        self.backgroundView = UIView()
+        self.backgroundView?.backgroundColor = UIColor.systemBackground
+
+        self.addSubview(self.stationTitleLabel)
+        self.stationTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.stationTitleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            self.stationTitleLabel.bottomAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+
+        self.addSubview(self.directionLabel)
+        self.directionLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.directionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            self.directionLabel.topAnchor.constraint(equalTo: self.stationTitleLabel.bottomAnchor, constant: 5)
+        ])
+    }
+}

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -7,9 +7,25 @@
 
 import UIKit
 
+protocol FavoriteHeaderViewDelegate {
+    func shouldGoToStationScene()
+}
+
 class FavoriteHeaderView: UICollectionReusableView {
 
     static let identifier = "FavoriteHeaderView"
+    
+    private var delegate: FavoriteHeaderViewDelegate? {
+        didSet {
+            let tapGesture = UITapGestureRecognizer()
+            tapGesture.addTarget(self, action: #selector(headerViewTapped(_:)))
+            self.addGestureRecognizer(tapGesture)
+        }
+    }
+    
+    @objc private func headerViewTapped(_ sender: UICollectionReusableView) {
+        delegate?.shouldGoToStationScene()
+    }
 
     private lazy var stationTitleLabel: UILabel = {
         let label = UILabel()
@@ -56,5 +72,9 @@ class FavoriteHeaderView: UICollectionReusableView {
 
     private func configureUI() {
         self.backgroundColor = UIColor.systemBackground
+    }
+    
+    func configureDelegate(_ delegate: FavoriteHeaderViewDelegate) {
+        self.delegate = delegate
     }
 }

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -38,7 +38,7 @@ class FavoriteHeaderView: UICollectionReusableView {
         let label = UILabel()
         label.text = "여의도 공원 방면"
         label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = UIColor(named: "bbusGray")
+        label.textColor = MyColor.bbusGray
         return label
     }()
 
@@ -53,7 +53,8 @@ class FavoriteHeaderView: UICollectionReusableView {
         self.configureLayout()
         self.configureUI()
     }
-
+    
+    // MARK: - Configuration
     private func configureLayout() {
 
         self.addSubview(self.stationTitleLabel)
@@ -72,7 +73,7 @@ class FavoriteHeaderView: UICollectionReusableView {
     }
 
     private func configureUI() {
-        self.backgroundColor = UIColor.systemBackground
+        self.backgroundColor = MyColor.white
     }
     
     func configureDelegate(_ delegate: FavoriteHeaderViewDelegate) {

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -17,6 +17,7 @@ class FavoriteHeaderView: UICollectionReusableView {
     
     private var delegate: FavoriteHeaderViewDelegate? {
         didSet {
+            self.gestureRecognizers?.forEach() { self.removeGestureRecognizer($0) }
             let tapGesture = UITapGestureRecognizer()
             tapGesture.addTarget(self, action: #selector(headerViewTapped(_:)))
             self.addGestureRecognizer(tapGesture)

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -60,7 +60,7 @@ class FavoriteHeaderView: UICollectionReusableView {
         self.stationTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.stationTitleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
-            self.stationTitleLabel.bottomAnchor.constraint(equalTo: self.centerYAnchor)
+            self.stationTitleLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -35)
         ])
 
         self.addSubview(self.directionLabel)

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -28,9 +28,14 @@ class FavoriteHeaderView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.configureLayout()
+        self.configureUI()
     }
 
-    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureLayout()
+        self.configureUI()
+    }
 
     private func configureLayout() {
 
@@ -47,5 +52,9 @@ class FavoriteHeaderView: UICollectionReusableView {
             self.directionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
             self.directionLabel.topAnchor.constraint(equalTo: self.stationTitleLabel.bottomAnchor, constant: 5)
         ])
+    }
+
+    private func configureUI() {
+        self.backgroundColor = UIColor.systemBackground
     }
 }

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class FavoriteHeaderView: UITableViewHeaderFooterView {
+class FavoriteHeaderView: UICollectionReusableView {
 
     static let identifier = "FavoriteHeaderView"
 
@@ -25,20 +25,14 @@ class FavoriteHeaderView: UITableViewHeaderFooterView {
         return label
     }()
 
-
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-        self.configureLayout()
-    }
-
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.configureLayout()
     }
 
+    
+
     private func configureLayout() {
-        self.backgroundView = UIView()
-        self.backgroundView?.backgroundColor = UIColor.systemBackground
 
         self.addSubview(self.stationTitleLabel)
         self.stationTitleLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -14,6 +14,7 @@ protocol FavoriteHeaderViewDelegate {
 class FavoriteHeaderView: UICollectionReusableView {
 
     static let identifier = "FavoriteHeaderView"
+    static let height: CGFloat = 70
     
     private var delegate: FavoriteHeaderViewDelegate? {
         didSet {
@@ -56,19 +57,22 @@ class FavoriteHeaderView: UICollectionReusableView {
     
     // MARK: - Configuration
     private func configureLayout() {
+        let leadingInterval: CGFloat = 20
+        let titleBottomInterval: CGFloat = -35
+        let titleDirectionInterval: CGFloat = 5
 
         self.addSubview(self.stationTitleLabel)
         self.stationTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.stationTitleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
-            self.stationTitleLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -35)
+            self.stationTitleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leadingInterval),
+            self.stationTitleLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: titleBottomInterval)
         ])
 
         self.addSubview(self.directionLabel)
         self.directionLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.directionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
-            self.directionLabel.topAnchor.constraint(equalTo: self.stationTitleLabel.bottomAnchor, constant: 5)
+            self.directionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leadingInterval),
+            self.directionLabel.topAnchor.constraint(equalTo: self.stationTitleLabel.bottomAnchor, constant: titleDirectionInterval)
         ])
     }
 

--- a/BBus/BBus/Home/View/FavoriteHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteHeaderView.swift
@@ -14,13 +14,13 @@ class FavoriteHeaderView: UITableViewHeaderFooterView {
     private lazy var stationTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "여의도환승센터(4번승강장)"
-        label.font = UIFont.boldSystemFont(ofSize: 20)
+        label.font = UIFont.boldSystemFont(ofSize: 17)
         return label
     }()
     private lazy var directionLabel: UILabel = {
         let label = UILabel()
         label.text = "여의도 공원 방면"
-        label.font = UIFont.systemFont(ofSize: 18)
+        label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(named: "bbusGray")
         return label
     }()

--- a/BBus/BBus/Home/View/FavoriteTableViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteTableViewCell.swift
@@ -1,0 +1,52 @@
+//
+//  FavoriteTableViewCell.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/02.
+//
+
+import UIKit
+
+class FavoriteTableViewCell: UITableViewCell {
+
+    static let identifier = "FavoriteTableViewCell"
+
+    private lazy var busNumberLabel: UILabel = {
+        let label = UILabel()
+        label.text = "272"
+        label.font = UIFont.boldSystemFont(ofSize: 25)
+        label.textColor = UIColor(named: "bbusTypeBlue")
+        return label
+    }()
+    private lazy var trailingView = BusCellTrailingView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.trailingView.configureLayout()
+        self.configureLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.trailingView.configureLayout()
+        self.configureLayout()
+    }
+
+    private func configureLayout() {
+        self.addSubview(self.busNumberLabel)
+        self.busNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.busNumberLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.busNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20)
+        ])
+
+        self.addSubview(self.trailingView)
+        self.trailingView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.trailingView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.trailingView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.trailingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.trailingView.widthAnchor.constraint(equalToConstant: self.frame.width / 2)
+        ])
+    }
+}

--- a/BBus/BBus/Home/View/FavoriteTableViewCell.swift
+++ b/BBus/BBus/Home/View/FavoriteTableViewCell.swift
@@ -14,7 +14,7 @@ class FavoriteTableViewCell: UITableViewCell {
     private lazy var busNumberLabel: UILabel = {
         let label = UILabel()
         label.text = "272"
-        label.font = UIFont.boldSystemFont(ofSize: 25)
+        label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = UIColor(named: "bbusTypeBlue")
         return label
     }()
@@ -46,7 +46,7 @@ class FavoriteTableViewCell: UITableViewCell {
             self.trailingView.topAnchor.constraint(equalTo: self.topAnchor),
             self.trailingView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.trailingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.trailingView.widthAnchor.constraint(equalToConstant: self.frame.width / 2)
+            self.trailingView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5)
         ])
     }
 }

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -22,12 +22,12 @@ class HomeNavigationView: UIView {
     }
     private lazy var searchButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = UIColor(named: "bbusLightGray")
-        button.layer.borderColor = UIColor(named: "bbusGray")?.cgColor
+        button.backgroundColor = MyColor.bbusLightGray
+        button.layer.borderColor = MyColor.bbusGray?.cgColor
         button.layer.borderWidth = 0.3
         button.layer.cornerRadius = 3
         button.setTitle("버스 또는 정류장 검색", for: .normal)
-        button.setTitleColor(UIColor(named: "bbusGray"), for: .normal)
+        button.setTitleColor(MyColor.bbusGray, for: .normal)
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
         return button
     }()
@@ -46,11 +46,12 @@ class HomeNavigationView: UIView {
         self.configureLayout()
     }
     
+    // MARK: - Configuration
     func configureLayout() {
         let navigationBottomBorderView = UIView()
         navigationBottomBorderView.backgroundColor = UIColor.gray
-        navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(navigationBottomBorderView)
+        navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             navigationBottomBorderView.topAnchor.constraint(equalTo: self.bottomAnchor, constant: -1),
             navigationBottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
@@ -58,8 +59,8 @@ class HomeNavigationView: UIView {
             navigationBottomBorderView.heightAnchor.constraint(equalToConstant: 0.2)
         ])
         
-        self.searchButton.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(self.searchButton)
+        self.searchButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.searchButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             self.searchButton.centerXAnchor.constraint(equalTo: self.centerXAnchor),

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -1,0 +1,60 @@
+//
+//  NavigationView.swift
+//  BBus
+//
+//  Created by 이지수 on 2021/11/03.
+//
+
+import UIKit
+
+class HomeNavigationView: UIView {
+    private lazy var searchButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = UIColor(named: "bbusLightGray")
+        button.layer.borderColor = UIColor(named: "bbusGray")?.cgColor
+        button.layer.borderWidth = 0.3
+        button.layer.cornerRadius = 3
+        button.setTitle("버스 또는 정류장 검색", for: .normal)
+        button.setTitleColor(UIColor(named: "bbusGray"), for: .normal)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
+        return button
+    }()
+    
+    convenience init() {
+        self.init(frame: CGRect())
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureLayout()
+    }
+    
+    func configureLayout() {
+        let navigationBottomBorderView = UIView()
+        navigationBottomBorderView.backgroundColor = UIColor.gray
+        navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(navigationBottomBorderView)
+        NSLayoutConstraint.activate([
+            navigationBottomBorderView.topAnchor.constraint(equalTo: self.bottomAnchor, constant: -1),
+            navigationBottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            navigationBottomBorderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            navigationBottomBorderView.heightAnchor.constraint(equalToConstant: 0.2)
+        ])
+        
+        self.searchButton.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(self.searchButton)
+        NSLayoutConstraint.activate([
+            self.searchButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.searchButton.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.searchButton.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.9),
+            self.searchButton.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.6)
+        ])
+        self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
+    }
+
+}

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -7,7 +7,19 @@
 
 import UIKit
 
+protocol HomeSearchButtonDelegate {
+    func shouldGoToSearchBusScene()
+}
+
 class HomeNavigationView: UIView {
+
+    private var searchButtonDelegate: HomeSearchButtonDelegate? {
+        didSet {
+            self.searchButton.addAction(UIAction(handler: { _ in
+                self.searchButtonDelegate?.shouldGoToSearchBusScene()
+            }), for: .touchUpInside)
+        }
+    }
     private lazy var searchButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = UIColor(named: "bbusLightGray")
@@ -55,6 +67,10 @@ class HomeNavigationView: UIView {
             self.searchButton.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.6)
         ])
         self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
+    }
+
+    func configureButtonDelegate(_ delegate: HomeSearchButtonDelegate) {
+        self.searchButtonDelegate = delegate
     }
 
 }

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -13,6 +13,8 @@ protocol HomeSearchButtonDelegate {
 
 class HomeNavigationView: UIView {
 
+    static let height: CGFloat = 50.0
+
     private var searchButtonDelegate: HomeSearchButtonDelegate? {
         didSet {
             self.searchButton.addAction(UIAction(handler: { _ in
@@ -31,9 +33,14 @@ class HomeNavigationView: UIView {
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
         return button
     }()
+    private lazy var bottomBorderView: UIView = {
+        let view = UIView()
+        view.backgroundColor = MyColor.gray
+        return view
+    }()
     
     convenience init() {
-        self.init(frame: CGRect(origin: CGPoint(), size: CGSize(width: 0, height: 50)))
+        self.init(frame: CGRect(origin: CGPoint(), size: CGSize(width: 0, height: Self.height)))
     }
     
     override init(frame: CGRect) {
@@ -48,26 +55,28 @@ class HomeNavigationView: UIView {
     
     // MARK: - Configuration
     func configureLayout() {
-        let navigationBottomBorderView = UIView()
-        navigationBottomBorderView.backgroundColor = UIColor.gray
-        self.addSubview(navigationBottomBorderView)
-        navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
+        let borderHeight: CGFloat = 0.2
+        self.addSubview(self.bottomBorderView)
+        self.bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            navigationBottomBorderView.topAnchor.constraint(equalTo: self.bottomAnchor, constant: -1),
-            navigationBottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            navigationBottomBorderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            navigationBottomBorderView.heightAnchor.constraint(equalToConstant: 0.2)
+            self.bottomBorderView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.bottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.bottomBorderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.bottomBorderView.heightAnchor.constraint(equalToConstant: borderHeight)
         ])
-        
+
+        let searchButtonWidthRatio: CGFloat = 0.9
+        let searchButtonHeightRatio: CGFloat = 0.6
+        let searchButtonTitleLeftPadding: CGFloat = 10
         self.addSubview(self.searchButton)
         self.searchButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.searchButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             self.searchButton.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            self.searchButton.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.9),
-            self.searchButton.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.6)
+            self.searchButton.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: searchButtonWidthRatio),
+            self.searchButton.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: searchButtonHeightRatio)
         ])
-        self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
+        self.searchButton.titleLabel?.leadingAnchor.constraint(equalTo: self.searchButton.leadingAnchor, constant: searchButtonTitleLeftPadding).isActive = true
     }
 
     func configureDelegate(_ delegate: HomeSearchButtonDelegate) {

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -69,7 +69,7 @@ class HomeNavigationView: UIView {
         self.searchButton.titleLabel?.leftAnchor.constraint(equalTo: self.searchButton.leftAnchor, constant: 10).isActive = true
     }
 
-    func configureButtonDelegate(_ delegate: HomeSearchButtonDelegate) {
+    func configureDelegate(_ delegate: HomeSearchButtonDelegate) {
         self.searchButtonDelegate = delegate
     }
 

--- a/BBus/BBus/Home/View/HomeNavigationView.swift
+++ b/BBus/BBus/Home/View/HomeNavigationView.swift
@@ -33,7 +33,7 @@ class HomeNavigationView: UIView {
     }()
     
     convenience init() {
-        self.init(frame: CGRect())
+        self.init(frame: CGRect(origin: CGPoint(), size: CGSize(width: 0, height: 50)))
     }
     
     override init(frame: CGRect) {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -10,7 +10,7 @@ import UIKit
 class HomeView: UIView {
 
     private lazy var favoriteTableView: UITableView = UITableView()
-    private lazy var refreshButton: UIButton = UIButton()
+    lazy var refreshButton: UIButton = UIButton()
 
     convenience init() {
         self.init(frame: CGRect())
@@ -19,7 +19,7 @@ class HomeView: UIView {
 
     func configureLayout() {
         self.addSubview(self.favoriteTableView)
-        self.favoriteTableView.backgroundColor = UIColor.blue
+        self.favoriteTableView.backgroundColor = UIColor.systemGray6
         self.favoriteTableView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.favoriteTableView.topAnchor.constraint(equalTo: self.topAnchor),
@@ -29,7 +29,7 @@ class HomeView: UIView {
         ])
 
         self.addSubview(self.refreshButton)
-        self.refreshButton.backgroundColor = UIColor.red
+        self.refreshButton.backgroundColor = UIColor.darkGray
         self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.refreshButton.widthAnchor.constraint(equalToConstant: 50),
@@ -37,6 +37,10 @@ class HomeView: UIView {
             self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
             self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
+    }
+
+    func showAlwaysButton() {
+        self.refreshButton.layer.zPosition = CGFloat.greatestFiniteMagnitude
     }
 
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -68,7 +68,7 @@ class HomeView: UIView {
     func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UICollectionViewDelegateFlowLayout & HomeSearchButtonDelegate) {
         self.favoriteCollectionView.delegate = delegate
         self.favoriteCollectionView.dataSource = delegate
-        self.navigationView.configureButtonDelegate(delegate)
+        self.navigationView.configureDelegate(delegate)
     }
 
     private func collectionViewLayout() -> UICollectionViewLayout {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -8,11 +8,17 @@
 import UIKit
 
 class HomeView: UIView {
-
+    
     private lazy var favoriteCollectionView: UICollectionView = {
         UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
     }()
-
+    private lazy var navigationView = HomeNavigationView()
+    private lazy var navigationBottomBorderView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.gray
+        view.isHidden = true
+        return view
+    }()
     lazy var refreshButton: UIButton = UIButton()
 
     convenience init() {
@@ -20,12 +26,29 @@ class HomeView: UIView {
     }
 
     func configureLayout() {
+        self.addSubview(self.navigationView)
+        self.navigationView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.navigationView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
+            self.navigationView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.navigationView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+        self.navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(self.navigationBottomBorderView)
+        NSLayoutConstraint.activate([
+            self.navigationBottomBorderView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.navigationBottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.navigationBottomBorderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.navigationBottomBorderView.heightAnchor.constraint(equalToConstant: 0.2)
+        ])
+        
         self.favoriteCollectionView.contentInsetAdjustmentBehavior = .never
         self.addSubview(self.favoriteCollectionView)
         self.favoriteCollectionView.backgroundColor = UIColor.systemGray6
         self.favoriteCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.favoriteCollectionView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.favoriteCollectionView.topAnchor.constraint(equalTo: self.navigationView.bottomAnchor),
             self.favoriteCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.favoriteCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.favoriteCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class HomeView: UIView {
 
-    private lazy var favoriteTableView: UITableView = UITableView()
+    private lazy var favoriteTableView: UITableView = UITableView(frame: CGRect(), style: .grouped)
     lazy var refreshButton: UIButton = UIButton()
 
     convenience init() {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -12,11 +12,9 @@ class HomeView: UIView {
     private lazy var favoriteCollectionView: UICollectionView = {
         UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
     }()
-    private lazy var navigationView = HomeNavigationView()
-    private lazy var navigationBottomBorderView: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.gray
-        view.isHidden = true
+    private lazy var navigationView: HomeNavigationView = {
+        let view = HomeNavigationView()
+        view.backgroundColor = UIColor.systemBackground
         return view
     }()
     lazy var refreshButton: UIButton = UIButton()
@@ -26,30 +24,12 @@ class HomeView: UIView {
     }
 
     func configureLayout() {
-        self.navigationView.clipsToBounds = true
-        self.addSubview(self.navigationView)
-        self.navigationView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.navigationView.topAnchor.constraint(equalTo: self.topAnchor),
-//            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
-            self.navigationView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.navigationView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
-        ])
-        self.navigationBottomBorderView.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(self.navigationBottomBorderView)
-        NSLayoutConstraint.activate([
-            self.navigationBottomBorderView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.navigationBottomBorderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.navigationBottomBorderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.navigationBottomBorderView.heightAnchor.constraint(equalToConstant: 0.2)
-        ])
-        
         self.favoriteCollectionView.contentInsetAdjustmentBehavior = .never
         self.addSubview(self.favoriteCollectionView)
         self.favoriteCollectionView.backgroundColor = UIColor.systemGray6
         self.favoriteCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.favoriteCollectionView.topAnchor.constraint(equalTo: self.navigationView.bottomAnchor),
+            self.favoriteCollectionView.topAnchor.constraint(equalTo: self.topAnchor),
             self.favoriteCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.favoriteCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.favoriteCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
@@ -63,6 +43,15 @@ class HomeView: UIView {
             self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
             self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
             self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
+        ])
+        
+        self.addSubview(self.navigationView)
+        self.navigationView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.navigationView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
+            self.navigationView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.navigationView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
     }
 
@@ -86,23 +75,9 @@ class HomeView: UIView {
         self.favoriteCollectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
     }
     
-    private var direction: Bool = false
-    
     func configureNavigationViewVisable(_ direction: Bool) {
-        if self.direction != direction {
-            UIView.animate(withDuration: TimeInterval(0.5), animations: {
-//                self.navigationView.frame.size = CGSize(width: self.navigationView.frame.width, height: 0)
-//                self.navigationView.layoutIfNeeded()
-                self.navigationView.transform = CGAffineTransform(translationX: 0, y: -50)
-                self.navigationView.alpha = 0
-            }, completion: { _ in
-                self.navigationView.isHidden = true
-            })
-        }
-        self.direction = direction
-        
-//        UIView.transition(with: self.navigationView, duration: 0.4, options: .transitionCrossDissolve, animations: {
-//            self.navigationView.isHidden = direction
-//        }, completion: nil)
+        UIView.animate(withDuration: TimeInterval(0.4), animations: {
+            self.navigationView.transform = CGAffineTransform(translationX: 0, y: direction ? 0 : -49 )
+        })
     }
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -26,11 +26,12 @@ class HomeView: UIView {
     }
 
     func configureLayout() {
+        self.navigationView.clipsToBounds = true
         self.addSubview(self.navigationView)
         self.navigationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.navigationView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
+//            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
             self.navigationView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.navigationView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
@@ -83,5 +84,25 @@ class HomeView: UIView {
     func configureReusableCell() {
         self.favoriteCollectionView.register(FavoriteHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteHeaderView.identifier)
         self.favoriteCollectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
+    }
+    
+    private var direction: Bool = false
+    
+    func configureNavigationViewVisable(_ direction: Bool) {
+        if self.direction != direction {
+            UIView.animate(withDuration: TimeInterval(0.5), animations: {
+//                self.navigationView.frame.size = CGSize(width: self.navigationView.frame.width, height: 0)
+//                self.navigationView.layoutIfNeeded()
+                self.navigationView.transform = CGAffineTransform(translationX: 0, y: -50)
+                self.navigationView.alpha = 0
+            }, completion: { _ in
+                self.navigationView.isHidden = true
+            })
+        }
+        self.direction = direction
+        
+//        UIView.transition(with: self.navigationView, duration: 0.4, options: .transitionCrossDissolve, animations: {
+//            self.navigationView.isHidden = direction
+//        }, completion: nil)
     }
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class HomeView: UIView {
+
+    private let refreshButtonWidth: CGFloat = 50
     
     private lazy var favoriteCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
@@ -23,7 +25,7 @@ class HomeView: UIView {
     lazy var refreshButton: UIButton = {
         let button = UIButton()
         button.setImage(MyImage.refresh, for: .normal)
-        button.layer.cornerRadius = 25
+        button.layer.cornerRadius = self.refreshButtonWidth / 2
         button.tintColor = UIColor.white
         return button
     }()
@@ -48,18 +50,19 @@ class HomeView: UIView {
         self.addSubview(self.refreshButton)
         self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
         self.refreshButton.backgroundColor = UIColor.darkGray
+        let refreshTrailingBottomInterval: CGFloat = -16
         NSLayoutConstraint.activate([
-            self.refreshButton.widthAnchor.constraint(equalToConstant: 50),
+            self.refreshButton.widthAnchor.constraint(equalToConstant: self.refreshButtonWidth),
             self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
-            self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
-            self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
+            self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: refreshTrailingBottomInterval),
+            self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: refreshTrailingBottomInterval)
         ])
         
         self.addSubview(self.navigationView)
         self.navigationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.navigationView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.navigationView.heightAnchor.constraint(equalToConstant: 50),
+            self.navigationView.heightAnchor.constraint(equalToConstant: HomeNavigationView.height),
             self.navigationView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.navigationView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
@@ -72,17 +75,22 @@ class HomeView: UIView {
     }
 
     func configureNavigationViewVisable(_ direction: Bool) {
-        UIView.animate(withDuration: TimeInterval(0.4), animations: {
-            self.navigationView.transform = CGAffineTransform(translationX: 0, y: direction ? 0 : -49 )
+        let animationDuration: TimeInterval = 0.4
+
+        UIView.animate(withDuration: animationDuration, animations: {
+            self.navigationView.transform = CGAffineTransform(translationX: 0, y: direction ? 0 : -HomeNavigationView.height + 1)
         })
     }
     
     private func collectionViewLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewFlowLayout()
+        let bottomLineHeight: CGFloat = 1
+        let sectionInterval: CGFloat = 10
+
         layout.scrollDirection = .vertical
-        layout.sectionInset = UIEdgeInsets(top: 1, left: 0, bottom: 10, right: 0)
-        layout.minimumInteritemSpacing = 1
-        layout.minimumLineSpacing = 1
+        layout.sectionInset = UIEdgeInsets(top: bottomLineHeight, left: 0, bottom: sectionInterval, right: 0)
+        layout.minimumInteritemSpacing = bottomLineHeight
+        layout.minimumLineSpacing = bottomLineHeight
         return layout
     }
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -7,14 +7,36 @@
 
 import UIKit
 
-class HomeView: UIStackView {
+class HomeView: UIView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    private lazy var favoriteTableView: UITableView = UITableView()
+    private lazy var refreshButton: UIButton = UIButton()
+
+    convenience init() {
+        self.init(frame: CGRect())
+        self.backgroundColor = .red
     }
-    */
+
+    func configureLayout() {
+        self.addSubview(self.favoriteTableView)
+        self.favoriteTableView.backgroundColor = UIColor.blue
+        self.favoriteTableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.favoriteTableView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.favoriteTableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.favoriteTableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.favoriteTableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+
+        self.addSubview(self.refreshButton)
+        self.refreshButton.backgroundColor = UIColor.red
+        self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.refreshButton.widthAnchor.constraint(equalToConstant: 50),
+            self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
+            self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
+        ])
+    }
 
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -18,7 +18,6 @@ class HomeView: UIView {
     convenience init() {
         self.init(frame: CGRect())
         self.backgroundColor = .red
-        self.configureReusableCell()
     }
 
     func configureLayout() {
@@ -44,7 +43,7 @@ class HomeView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource) {
+    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UICollectionViewDelegateFlowLayout) {
         self.favoriteCollectionView.delegate = delegate
         self.favoriteCollectionView.dataSource = delegate
     }
@@ -54,11 +53,10 @@ class HomeView: UIView {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
-        layout.itemSize = CGSize(width: self.frame.width, height: 70)
         return layout
     }
 
-    private func configureReusableCell() {
+    func configureReusableCell() {
         self.favoriteCollectionView.register(FavoriteHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteHeaderView.identifier)
         self.favoriteCollectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
     }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -65,9 +65,10 @@ class HomeView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UICollectionViewDelegateFlowLayout) {
+    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UICollectionViewDelegateFlowLayout & HomeSearchButtonDelegate) {
         self.favoriteCollectionView.delegate = delegate
         self.favoriteCollectionView.dataSource = delegate
+        self.navigationView.configureButtonDelegate(delegate)
     }
 
     private func collectionViewLayout() -> UICollectionViewLayout {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -19,6 +19,7 @@ class HomeView: UIView {
     }
 
     func configureLayout() {
+        self.favoriteTableView.contentInsetAdjustmentBehavior = .never
         self.addSubview(self.favoriteTableView)
         self.favoriteTableView.backgroundColor = UIColor.systemGray6
         self.favoriteTableView.translatesAutoresizingMaskIntoConstraints = false

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -15,6 +15,7 @@ class HomeView: UIView {
     convenience init() {
         self.init(frame: CGRect())
         self.backgroundColor = .red
+        self.configureReusableCell()
     }
 
     func configureLayout() {
@@ -37,5 +38,15 @@ class HomeView: UIView {
             self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
             self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
+    }
+
+    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource) {
+        self.favoriteTableView.delegate = delegate
+        self.favoriteTableView.dataSource = delegate
+    }
+
+    private func configureReusableCell() {
+        self.favoriteTableView.register(FavoriteTableViewCell.self, forCellReuseIdentifier: FavoriteTableViewCell.identifier)
+        self.favoriteTableView.register(FavoriteHeaderView.self, forHeaderFooterViewReuseIdentifier: FavoriteHeaderView.identifier)
     }
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -17,7 +17,14 @@ class HomeView: UIView {
         view.backgroundColor = UIColor.systemBackground
         return view
     }()
-    lazy var refreshButton: UIButton = UIButton()
+    lazy var refreshButton: UIButton = {
+        let button = UIButton()
+        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
+        button.setImage(UIImage(systemName: "arrow.triangle.2.circlepath", withConfiguration: largeConfig), for: .normal)
+        button.layer.cornerRadius = 25
+        button.tintColor = UIColor.white
+        return button
+    }()
 
     convenience init() {
         self.init(frame: CGRect())

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -9,7 +9,10 @@ import UIKit
 
 class HomeView: UIView {
 
-    private lazy var favoriteTableView: UITableView = UITableView(frame: CGRect(), style: .grouped)
+    private lazy var favoriteCollectionView: UICollectionView = {
+        UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
+    }()
+
     lazy var refreshButton: UIButton = UIButton()
 
     convenience init() {
@@ -19,15 +22,15 @@ class HomeView: UIView {
     }
 
     func configureLayout() {
-        self.favoriteTableView.contentInsetAdjustmentBehavior = .never
-        self.addSubview(self.favoriteTableView)
-        self.favoriteTableView.backgroundColor = UIColor.systemGray6
-        self.favoriteTableView.translatesAutoresizingMaskIntoConstraints = false
+        self.favoriteCollectionView.contentInsetAdjustmentBehavior = .never
+        self.addSubview(self.favoriteCollectionView)
+        self.favoriteCollectionView.backgroundColor = UIColor.systemGray6
+        self.favoriteCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.favoriteTableView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.favoriteTableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            self.favoriteTableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.favoriteTableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+            self.favoriteCollectionView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.favoriteCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.favoriteCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.favoriteCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
 
         self.addSubview(self.refreshButton)
@@ -41,13 +44,22 @@ class HomeView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource) {
-        self.favoriteTableView.delegate = delegate
-        self.favoriteTableView.dataSource = delegate
+    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource) {
+        self.favoriteCollectionView.delegate = delegate
+        self.favoriteCollectionView.dataSource = delegate
+    }
+
+    private func collectionViewLayout() -> UICollectionViewLayout {
+        print(self.frame)
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+        layout.itemSize = CGSize(width: self.frame.width, height: 70)
+        return layout
     }
 
     private func configureReusableCell() {
-        self.favoriteTableView.register(FavoriteTableViewCell.self, forCellReuseIdentifier: FavoriteTableViewCell.identifier)
-        self.favoriteTableView.register(FavoriteHeaderView.self, forHeaderFooterViewReuseIdentifier: FavoriteHeaderView.identifier)
+        self.favoriteCollectionView.register(FavoriteHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteHeaderView.identifier)
+        self.favoriteCollectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
     }
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -38,9 +38,4 @@ class HomeView: UIView {
             self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
     }
-
-    func showAlwaysButton() {
-        self.refreshButton.layer.zPosition = CGFloat.greatestFiniteMagnitude
-    }
-
 }

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -17,7 +17,6 @@ class HomeView: UIView {
 
     convenience init() {
         self.init(frame: CGRect())
-        self.backgroundColor = .red
     }
 
     func configureLayout() {
@@ -49,10 +48,11 @@ class HomeView: UIView {
     }
 
     private func collectionViewLayout() -> UICollectionViewLayout {
-        print(self.frame)
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+        layout.sectionInset = UIEdgeInsets(top: 1, left: 0, bottom: 10, right: 0)
+        layout.minimumInteritemSpacing = 1
+        layout.minimumLineSpacing = 1
         return layout
     }
 

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -10,17 +10,19 @@ import UIKit
 class HomeView: UIView {
     
     private lazy var favoriteCollectionView: UICollectionView = {
-        UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
+        let collectionView = UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
+        collectionView.register(FavoriteHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteHeaderView.identifier)
+        collectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
+        return collectionView
     }()
     private lazy var navigationView: HomeNavigationView = {
         let view = HomeNavigationView()
-        view.backgroundColor = UIColor.systemBackground
+        view.backgroundColor = MyColor.white
         return view
     }()
     lazy var refreshButton: UIButton = {
         let button = UIButton()
-        let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
-        button.setImage(UIImage(systemName: "arrow.triangle.2.circlepath", withConfiguration: largeConfig), for: .normal)
+        button.setImage(MyImage.refresh, for: .normal)
         button.layer.cornerRadius = 25
         button.tintColor = UIColor.white
         return button
@@ -30,11 +32,12 @@ class HomeView: UIView {
         self.init(frame: CGRect())
     }
 
+    // MARK: - Configuration
     func configureLayout() {
         self.favoriteCollectionView.contentInsetAdjustmentBehavior = .never
         self.addSubview(self.favoriteCollectionView)
-        self.favoriteCollectionView.backgroundColor = UIColor.systemGray6
         self.favoriteCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        self.favoriteCollectionView.backgroundColor = MyColor.systemGray6
         NSLayoutConstraint.activate([
             self.favoriteCollectionView.topAnchor.constraint(equalTo: self.topAnchor),
             self.favoriteCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
@@ -43,8 +46,8 @@ class HomeView: UIView {
         ])
 
         self.addSubview(self.refreshButton)
-        self.refreshButton.backgroundColor = UIColor.darkGray
         self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
+        self.refreshButton.backgroundColor = UIColor.darkGray
         NSLayoutConstraint.activate([
             self.refreshButton.widthAnchor.constraint(equalToConstant: 50),
             self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
@@ -68,6 +71,12 @@ class HomeView: UIView {
         self.navigationView.configureDelegate(delegate)
     }
 
+    func configureNavigationViewVisable(_ direction: Bool) {
+        UIView.animate(withDuration: TimeInterval(0.4), animations: {
+            self.navigationView.transform = CGAffineTransform(translationX: 0, y: direction ? 0 : -49 )
+        })
+    }
+    
     private func collectionViewLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
@@ -75,16 +84,5 @@ class HomeView: UIView {
         layout.minimumInteritemSpacing = 1
         layout.minimumLineSpacing = 1
         return layout
-    }
-
-    func configureReusableCell() {
-        self.favoriteCollectionView.register(FavoriteHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteHeaderView.identifier)
-        self.favoriteCollectionView.register(FavoriteCollectionViewCell.self, forCellWithReuseIdentifier: FavoriteCollectionViewCell.identifier)
-    }
-    
-    func configureNavigationViewVisable(_ direction: Bool) {
-        UIView.animate(withDuration: TimeInterval(0.4), animations: {
-            self.navigationView.transform = CGAffineTransform(translationX: 0, y: direction ? 0 : -49 )
-        })
     }
 }

--- a/BBus/BBus/Home/ViewModel/HomeViewModel.swift
+++ b/BBus/BBus/Home/ViewModel/HomeViewModel.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+import Combine
+
+class HomeViewModel {
+
+    private let useCase: HomeUseCase
+
+    init(useCase: HomeUseCase) {
+        self.useCase = useCase
+    }
+}

--- a/BBus/BBus/SceneDelegate.swift
+++ b/BBus/BBus/SceneDelegate.swift
@@ -10,21 +10,15 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         self.window = UIWindow(windowScene: windowScene)
-        let useCase = HomeUseCase()
-        let viewModel = HomeViewModel(useCase: useCase)
-        let viewController = HomeViewController(viewModel: viewModel)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
+        guard let window = self.window else { return }
+        self.appCoordinator = AppCoordinator(window: window)
+        appCoordinator?.start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/BBus/BBus/SceneDelegate.swift
+++ b/BBus/BBus/SceneDelegate.swift
@@ -19,7 +19,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         self.window = UIWindow(windowScene: windowScene)
-        let viewController = HomeViewController()
+        let useCase = HomeUseCase()
+        let viewModel = HomeViewModel(useCase: useCase)
+        let viewController = HomeViewController(viewModel: viewModel)
         let navigationController = UINavigationController(rootViewController: viewController)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()

--- a/BBus/BBus/SearchBus/SearchBusCoordinator.swift
+++ b/BBus/BBus/SearchBus/SearchBusCoordinator.swift
@@ -1,0 +1,29 @@
+//
+//  SearchBusCoordinator.swift
+//  BBus
+//
+//  Created by Kang Minsang on 2021/11/02.
+//
+
+import UIKit
+
+class SearchBusCoordinator: NSObject, Coordinator {
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+        self.childCoordinators = []
+    }
+
+    func start() {
+        let viewController = SearchBusViewController()
+        viewController.coordinator = self
+        presenter.pushViewController(viewController, animated: true)
+    }
+
+    func terminate() {
+        self.coordinatorDidFinish()
+    }
+}

--- a/BBus/BBus/SearchBus/SearchBusViewController.swift
+++ b/BBus/BBus/SearchBus/SearchBusViewController.swift
@@ -9,12 +9,19 @@ import UIKit
 
 class SearchBusViewController: UIViewController {
 
+    private lazy var searchTextField: UITextField = {
+        let textField = UITextField(frame: CGRect(origin: CGPoint(), size: CGSize(width: self.view.frame.width - (self.navigationItem.leftBarButtonItem?.width ?? 0), height: 30)))
+        textField.placeholder = "버스 입력"
+        textField.backgroundColor = UIColor.gray
+        return textField
+    }()
     weak var coordinator: SearchBusCoordinator?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "SearchBus"
-        self.view.backgroundColor = .red
+        self.view.backgroundColor = UIColor.green
+        self.navigationItem.titleView = self.searchTextField
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/BBus/BBus/SearchBus/SearchBusViewController.swift
+++ b/BBus/BBus/SearchBus/SearchBusViewController.swift
@@ -9,21 +9,18 @@ import UIKit
 
 class SearchBusViewController: UIViewController {
 
+    weak var coordinator: SearchBusCoordinator?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        self.title = "SearchBus"
+        self.view.backgroundColor = .red
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if self.isMovingFromParent {
+            self.coordinator?.terminate()
+        }
     }
-    */
-
 }

--- a/BBus/BBus/Station/StationCoodinator.swift
+++ b/BBus/BBus/Station/StationCoodinator.swift
@@ -1,0 +1,29 @@
+//
+//  StationCoodinator.swift
+//  BBus
+//
+//  Created by 이지수 on 2021/11/03.
+//
+
+import UIKit
+
+class StationCoordinator: NSObject, Coordinator {
+    var delegate: CoordinatorFinishDelegate?
+    var presenter: UINavigationController
+    var childCoordinators: [Coordinator]
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+        self.childCoordinators = []
+    }
+
+    func start() {
+        let viewController = StationViewController()
+        viewController.coordinator = self
+        presenter.pushViewController(viewController, animated: true)
+    }
+
+    func terminate() {
+        self.coordinatorDidFinish()
+    }
+}

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -9,21 +9,17 @@ import UIKit
 
 class StationViewController: UIViewController {
 
+    weak var coordinator: StationCoordinator?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        self.view.backgroundColor = UIColor.red
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if self.isMovingFromParent {
+            self.coordinator?.terminate()
+        }
     }
-    */
-
 }


### PR DESCRIPTION
## 작업 내용
- [x] 검색 화면 이동 
- [x] 즐겨찾기 목록 조회
- [x] 즐겨찾기 목록 헤더 클릭 시 정거장 화면 이동
- [x] 즐겨찾기 목록 셀 클릭 시 버스 화면 이동
- [x] 새로고침 버튼 추가

## 시연 방법
|검색 화면으로 이동|전체적인 뷰, 네비게이션 사라지는 효과|헤더를 눌렀을때 정거장 화면으로 이동|
|:-:|:-:|:-:|
|![1-1 시연 1](https://user-images.githubusercontent.com/43032377/140058039-f877f59e-5b28-4d0a-bbe2-20c6d966c19d.gif)|![1-1 시연 2](https://user-images.githubusercontent.com/43032377/140058053-68b681fc-e568-4fad-b46d-f5424bb726ff.gif)|![1-1 시연 3](https://user-images.githubusercontent.com/72058473/140058170-e20b9491-e0c7-4750-9a0d-b0dbc37b1dd9.gif)|

|아이템을 눌렀을 때 버스노선 화면으로 이동|알람 버튼을 눌렀을 때 알람 화면으로 이동|
|:-:|:-:|
|![1-1 시연 4](https://user-images.githubusercontent.com/72058473/140058199-c88c0ccb-fad4-4949-8d3c-1a5edbb2a5ff.gif)|![1-1 시연 5](https://user-images.githubusercontent.com/72058473/140058206-338ab9f1-7844-4f64-85ac-fbb85f938043.gif)|

## 기타 (고민과 해결, 리뷰 포인트 등)
* 테이블뷰의 Delegate 내에 Header를 설정하는 부분이 있는 문제
  * **CollectionView 선택**
    * 이유
      - 역할과 책임을 확실하게 분배하기 위해서
      - 복잡한 헤더의 구성은 CollectionView가 하는게 맞다고 생각됨
      - 셀 내부에 있는 버튼의 Action을 처리하기 까다로워서

* 애니메이션
  * 네비게이션 바에 해당하는 뷰가 스크롤이 내려갈때 사라지고 올라갈 때 다시 나타나는 애니메이션을 표현해야함.
    * CGTransformAffine 으로 해결

* addAction이 여러번 중복으로 실행되어 특정 상황시 화면전환이 여러 번 되는 현상
  * CollectionView의 Item이 Reuse 되기 때문에, 이전에 각 버튼에 있던 action들이 사라지지 않고 남아 있어 생기는 문제.
  * addAction을 하는 시점 바로 전에 모든 action들을 지워줌으로써 해결