### PR TITLE
[검색] 2-4. 셀을 터치하면 노선도 화면으로 이동해야 한다.

### DIFF
--- a/BBus/BBus/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/BusRoute/BusRouteCoordinator.swift
@@ -15,7 +15,9 @@ class BusRouteCoordinator: StationPushable {
         self.navigationPresenter = presenter
     }
 
-    func start() {
+    func start(busRouteId: Int) {
+        // TODO: inject busRouteId
+        print(busRouteId)
         let viewController = BusRouteViewController()
         viewController.coordinator = self
         self.navigationPresenter.pushViewController(viewController, animated: true)

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -85,12 +85,12 @@ extension AppCoordinator: CoordinatorCreateDelegate {
         coordinator.start()
     }
 
-    func pushBusRoute() {
+    func pushBusRoute(busRouteId: Int) {
         let coordinator = BusRouteCoordinator(presenter: self.navigationPresenter)
         coordinator.delegate = self
         coordinator.navigationPresenter = self.navigationPresenter
         self.childCoordinators.append(coordinator)
-        coordinator.start()
+        coordinator.start(busRouteId: busRouteId)
     }
 
     func pushAlarmSetting() {

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -14,7 +14,7 @@ protocol CoordinatorFinishDelegate: AnyObject {
 
 protocol CoordinatorCreateDelegate {
     func pushSearch()
-    func pushBusRoute()
+    func pushBusRoute(busRouteId: Int)
     func pushAlarmSetting()
     func pushStation()
 }

--- a/BBus/BBus/Global/Coordinator/Pushables.swift
+++ b/BBus/BBus/Global/Coordinator/Pushables.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 protocol BusRoutePushable: Coordinator {
-    func pushToBusRoute()
+    func pushToBusRoute(busRouteId: Int)
 }
 
 extension BusRoutePushable {
-    func pushToBusRoute() {
-        self.delegate?.pushBusRoute()
+    func pushToBusRoute(busRouteId: Int) {
+        self.delegate?.pushBusRoute(busRouteId: busRouteId)
     }
 }
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -74,7 +74,7 @@ extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: Model binding Logic needed
 
-        self.coordinator?.pushToBusRoute()
+        self.coordinator?.pushToBusRoute(busRouteId: 272)
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -85,7 +85,8 @@ extension SearchViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.searchView.currentSearchType == SearchType.bus {
-            self.coordinator?.pushToBusRoute()
+            guard let busRouteId = self.viewModel?.busSearchResult[indexPath.row].routeID else { return }
+            self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
         }
         else {
             self.coordinator?.pushToStation()

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -113,7 +113,7 @@ class StationViewController: UIViewController {
 // MARK: - Delegate : CollectionView
 extension StationViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.coordinator?.pushToBusRoute()
+        self.coordinator?.pushToBusRoute(busRouteId: 272)
     }
 }
 


### PR DESCRIPTION
close #44 

## 작업 내용
- [x] 터치된 셀의 버스노선 ID를 다음 화면으로 전달 

## 시연 방법

화면 전환 시 버스노선 id가 출력되는 모습.

https://user-images.githubusercontent.com/70833900/141274682-ae80577c-93e3-418a-8fcd-e6c17cfed0c1.mov


## 기타 (고민과 해결, 리뷰 포인트 등)
- 넘겨받은 busRouteId를 coordinator에서 어떻게 처리할 것인가?
  1. let busRouteId: Int 처럼 프로퍼티로 가지고 있다가 start() 할 때 사용한다.
  2. AppCoordinator에서 BusRouteCooridnator.start(busRouteId: 33) 처럼 start의 인자로 넘겨준다.
  - Coordinator의 역할 측면에서 busRouteId를 프로퍼티로 **저장**하고 있을 필요는 없다고 생각함.
  - 넘겨받아서 다음화면에 전달을 해주기만 하면 되므로 start에서 인자로 받아 사용하고 끝내는 것이 맞다고 판단함.