### PR TITLE
[버스 노선도 정보] 7-1. 특정 버스 노선 id를 통해 xml 파일을 얻어올 수 있어야 한다

### DIFF
--- a/BBus/BBus/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/BusRoute/BusRouteCoordinator.swift
@@ -16,6 +16,8 @@ class BusRouteCoordinator: StationPushable {
     }
 
     func start() {
+        let usecase = BusRouteUsecase(usecases: BBusAPIUsecases(), busRouteId: 100100071)
+        let viewModel = BusRouteViewModel(usecase: usecase)
         let viewController = BusRouteViewController()
         viewController.coordinator = self
         self.navigationPresenter.pushViewController(viewController, animated: true)

--- a/BBus/BBus/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/BusRoute/BusRouteCoordinator.swift
@@ -18,7 +18,7 @@ class BusRouteCoordinator: StationPushable {
     func start() {
         let usecase = BusRouteUsecase(usecases: BBusAPIUsecases(), busRouteId: 100100071)
         let viewModel = BusRouteViewModel(usecase: usecase)
-        let viewController = BusRouteViewController()
+        let viewController = BusRouteViewController(viewModel: viewModel)
         viewController.coordinator = self
         self.navigationPresenter.pushViewController(viewController, animated: true)
     }

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -6,3 +6,30 @@
 //
 
 import Foundation
+import Combine
+
+class BusRouteUsecase {
+
+    private let usecases: GetRouteListUsecase
+    @Published var header: BusRouteDTO?
+    private var cancellable: AnyCancellable?
+    static let thread = DispatchQueue(label: "BusRoute")
+
+    init(usecases: GetRouteListUsecase, busRouteId: String) {
+        self.usecases = usecases
+        self.searchHeader(busRouteId: busRouteId)
+    }
+
+    private func searchHeader(busRouteId: String) {
+        self.cancellable = usecases.getRouteList()
+            .receive(on: Self.thread)
+            .decode(type: [BusRouteDTO].self, decoder: JSONDecoder())
+            .sink(receiveCompletion: { error in
+                if case .failure(let error) = error {
+                    print(error)
+                }
+            }, receiveValue: { routeList in
+                self.header = routeList[0]
+            })
+    }
+}

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -15,12 +15,12 @@ class BusRouteUsecase {
     private var cancellable: AnyCancellable?
     static let thread = DispatchQueue(label: "BusRoute")
 
-    init(usecases: GetRouteListUsecase, busRouteId: String) {
+    init(usecases: GetRouteListUsecase, busRouteId: Int) {
         self.usecases = usecases
         self.searchHeader(busRouteId: busRouteId)
     }
 
-    private func searchHeader(busRouteId: String) {
+    private func searchHeader(busRouteId: Int) {
         self.cancellable = usecases.getRouteList()
             .receive(on: Self.thread)
             .decode(type: [BusRouteDTO].self, decoder: JSONDecoder())
@@ -29,7 +29,7 @@ class BusRouteUsecase {
                     print(error)
                 }
             }, receiveValue: { routeList in
-                self.header = routeList[0]
+                self.header = routeList.filter { $0.routeID == busRouteId }[0]
             })
     }
 }

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -10,17 +10,18 @@ import Combine
 
 class BusRouteUsecase {
 
+    private let busRouteId: Int
     private let usecases: GetRouteListUsecase
     @Published var header: BusRouteDTO?
     private var cancellable: AnyCancellable?
     static let thread = DispatchQueue(label: "BusRoute")
 
     init(usecases: GetRouteListUsecase, busRouteId: Int) {
+        self.busRouteId = busRouteId
         self.usecases = usecases
-        self.searchHeader(busRouteId: busRouteId)
     }
 
-    private func searchHeader(busRouteId: Int) {
+    func searchHeader() {
         self.cancellable = usecases.getRouteList()
             .receive(on: Self.thread)
             .decode(type: [BusRouteDTO].self, decoder: JSONDecoder())
@@ -29,7 +30,7 @@ class BusRouteUsecase {
                     print(error)
                 }
             }, receiveValue: { routeList in
-                self.header = routeList.filter { $0.routeID == busRouteId }[0]
+                self.header = routeList.filter { $0.routeID == self.busRouteId }[0]
             })
     }
 }

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -6,3 +6,27 @@
 //
 
 import Foundation
+import Combine
+
+class BusRouteViewModel {
+
+    private let usecase: BusRouteUsecase
+    private var cancellables: Set<AnyCancellable>
+    @Published var header: BusRouteDTO?
+
+    init(usecase: BusRouteUsecase) {
+        self.usecase = usecase
+        self.cancellables = []
+        self.getHeaderInfo()
+    }
+
+    private func getHeaderInfo() {
+        self.usecase.searchHeader()
+        self.usecase.$header
+            .receive(on: BusRouteUsecase.thread)
+            .sink { _ in
+                self.header = self.usecase.header
+            }
+            .store(in: &cancellables)
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [x] coordinator 에서 주입된 버스노선ID 값에 따라 usecase 에서 header 내용을 얻는다
- [x] viewModel 에서 usecase 에서 받은 header 값이 변경되면 해당 header를 받는다
- [x] viewController 에서 viewModel 에서 받은 header 값이 변경되면 해당 header 를 받는다
- [x] viewController 에서 받은 header 내용을 토대로 header 내용을 configure 한다

## 시연 방법
<img src="https://user-images.githubusercontent.com/65349445/141283371-3d4aab06-6bbe-45de-bf12-98f2f720fb8b.gif" width=300>

- BusRouteCoordinator 에서 넣어준 특정 `busRouteId` 값에 따라 header 내용이 바뀐다

```Swift
func start() {
        let usecase = BusRouteUsecase(usecases: BBusAPIUsecases(), busRouteId: 100100071)
        let viewModel = BusRouteViewModel(usecase: usecase)
        let viewController = BusRouteViewController(viewModel: viewModel)
        viewController.coordinator = self
        self.navigationPresenter.pushViewController(viewController, animated: true)
    }
```

## 기타 (고민과 해결, 리뷰 포인트 등)
- Combine 에서 $header 를 통해 변화를 인지할 수는 있으나, 어떻게 값을 직접받는지는 모르기에
- 현재로서는 이러한 형태로 구현된 상태이다..

```Swift
private func bindingBusRouteHeaderResult() {
        self.viewModel?.$header
            .receive(on: BusRouteUsecase.thread)
            .sink(receiveValue: { _ in
                guard let header = self.viewModel?.header else { return }
                DispatchQueue.main.async {
                    self.busRouteView.configureHeaderView(busType: header.routeType.rawValue+"버스",
                                                          busNumber: header.busRouteName,
                                                          fromStation: header.startStation,
                                                          toStation: header.endStation)
                }
            })
            .store(in: &cancellables)
    }
```
