### PR TITLE
[검색] 3-2. 검색어를 가지고 정거장 이름 혹은 번호에 대응되는 정거장 id를 얻어올 수 있어야 한다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		4ACA51E5272FCD9C00EC0531 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */; };
 		4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E6272FCDA600EC0531 /* HomeViewModel.swift */; };
 		4ACA51E9272FCDAE00EC0531 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51E8272FCDAE00EC0531 /* HomeView.swift */; };
-		4ACA51EF272FCDE600EC0531 /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51EE272FCDE600EC0531 /* SearchModel.swift */; };
+		4ACA51EF272FCDE600EC0531 /* StationSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51EE272FCDE600EC0531 /* StationSearchResult.swift */; };
 		4ACA51F1272FCDF200EC0531 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51F0272FCDF200EC0531 /* SearchUseCase.swift */; };
 		4ACA51F3272FCDF900EC0531 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51F2272FCDF900EC0531 /* SearchViewModel.swift */; };
 		4ACA51F5272FCE0200EC0531 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA51F4272FCE0200EC0531 /* SearchView.swift */; };
@@ -163,7 +163,7 @@
 		4ACA51E4272FCD9C00EC0531 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
 		4ACA51E6272FCDA600EC0531 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		4ACA51E8272FCDAE00EC0531 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
-		4ACA51EE272FCDE600EC0531 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
+		4ACA51EE272FCDE600EC0531 /* StationSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSearchResult.swift; sourceTree = "<group>"; };
 		4ACA51F0272FCDF200EC0531 /* SearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
 		4ACA51F2272FCDF900EC0531 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		4ACA51F4272FCE0200EC0531 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -438,7 +438,7 @@
 		4ACA51ED272FCDD900EC0531 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				4ACA51EE272FCDE600EC0531 /* SearchModel.swift */,
+				4ACA51EE272FCDE600EC0531 /* StationSearchResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -787,7 +787,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4ACA5231272FCEE600EC0531 /* MovingStatusView.swift in Sources */,
-				4ACA51EF272FCDE600EC0531 /* SearchModel.swift in Sources */,
+				4ACA51EF272FCDE600EC0531 /* StationSearchResult.swift in Sources */,
 				4A17CED92733B5C6007B1646 /* SearchResultScrollView.swift in Sources */,
 				4ACA523B272FCF3C00EC0531 /* AlarmSettingViewController.swift in Sources */,
 				4ACA5221272FCEAF00EC0531 /* AlarmSettingUseCase.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041A5A10273D2E1B00490075 /* StringExtension.swift */; };
 		04214061273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */; };
 		0476ABBB27310ED200F72DD1 /* BusRouteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476ABBA27310ED200F72DD1 /* BusRouteHeaderView.swift */; };
 		0476ABBD27311C1600F72DD1 /* BusStationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476ABBC27311C1600F72DD1 /* BusStationTableViewCell.swift */; };
@@ -115,6 +116,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		041A5A10273D2E1B00490075 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusFoldUnfoldDelegate.swift; sourceTree = "<group>"; };
 		0476ABBA27310ED200F72DD1 /* BusRouteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteHeaderView.swift; sourceTree = "<group>"; };
 		0476ABBC27311C1600F72DD1 /* BusStationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusStationTableViewCell.swift; sourceTree = "<group>"; };
@@ -233,6 +235,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		041A5A0F273D2E0400490075 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				041A5A10273D2E1B00490075 /* StringExtension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		047C30F8273A044C0075EA14 /* Constant */ = {
 			isa = PBXGroup;
 			children = (
@@ -252,6 +262,7 @@
 				87038A80273B90810078EAE3 /* Network */,
 				873D6394273039C400E79069 /* Coordinator */,
 				047C30F8273A044C0075EA14 /* Constant */,
+				041A5A0F273D2E0400490075 /* Extension */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -825,6 +836,7 @@
 				4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */,
 				4ACA5213272FCE8500EC0531 /* StationModel.swift in Sources */,
 				04AC7D112733AF090095CD4E /* BusRouteTableViewCell.swift in Sources */,
+				041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */,
 				87038A8E273C10480078EAE3 /* GetRouteInfoItemFetcher.swift in Sources */,
 				4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */,
 				049375AF273BAA130061ACDA /* StationDTO.swift in Sources */,

--- a/BBus/BBus/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/BusRoute/BusRouteCoordinator.swift
@@ -15,7 +15,9 @@ class BusRouteCoordinator: StationPushable {
         self.navigationPresenter = presenter
     }
 
-    func start() {
+    func start(busRouteId: Int) {
+        // TODO: inject busRouteId
+        print(busRouteId)
         let viewController = BusRouteViewController()
         viewController.coordinator = self
         self.navigationPresenter.pushViewController(viewController, animated: true)

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -85,12 +85,12 @@ extension AppCoordinator: CoordinatorCreateDelegate {
         coordinator.start()
     }
 
-    func pushBusRoute() {
+    func pushBusRoute(busRouteId: Int) {
         let coordinator = BusRouteCoordinator(presenter: self.navigationPresenter)
         coordinator.delegate = self
         coordinator.navigationPresenter = self.navigationPresenter
         self.childCoordinators.append(coordinator)
-        coordinator.start()
+        coordinator.start(busRouteId: busRouteId)
     }
 
     func pushAlarmSetting() {

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -14,7 +14,7 @@ protocol CoordinatorFinishDelegate: AnyObject {
 
 protocol CoordinatorCreateDelegate {
     func pushSearch()
-    func pushBusRoute()
+    func pushBusRoute(busRouteId: Int)
     func pushAlarmSetting()
     func pushStation()
 }

--- a/BBus/BBus/Global/Coordinator/Pushables.swift
+++ b/BBus/BBus/Global/Coordinator/Pushables.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 protocol BusRoutePushable: Coordinator {
-    func pushToBusRoute()
+    func pushToBusRoute(busRouteId: Int)
 }
 
 extension BusRoutePushable {
-    func pushToBusRoute() {
-        self.delegate?.pushBusRoute()
+    func pushToBusRoute(busRouteId: Int) {
+        self.delegate?.pushBusRoute(busRouteId: busRouteId)
     }
 }
 

--- a/BBus/BBus/Global/Extension/StringExtension.swift
+++ b/BBus/BBus/Global/Extension/StringExtension.swift
@@ -1,0 +1,25 @@
+//
+//  StringExtension.swift
+//  BBus
+//
+//  Created by 최수정 on 2021/11/11.
+//
+
+import Foundation
+
+extension String {
+    func ranges(of substring: String) -> [Range<String.Index>] {
+        var ranges = [Range<String.Index>]()
+        var lowerBound = self.startIndex
+        let upperBound = self.endIndex
+        
+        while let range = self.range(of: substring,
+                                     options: [],
+                                     range: lowerBound..<upperBound) {
+            ranges.append(range)
+            lowerBound = range.upperBound
+        }
+        
+        return ranges
+    }
+}

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -74,7 +74,7 @@ extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: Model binding Logic needed
 
-        self.coordinator?.pushToBusRoute()
+        self.coordinator?.pushToBusRoute(busRouteId: 272)
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/BBus/BBus/Search/Model/SearchModel.swift
+++ b/BBus/BBus/Search/Model/SearchModel.swift
@@ -1,8 +1,0 @@
-//
-//  SearchBusModel.swift
-//  BBus
-//
-//  Created by 김태훈 on 2021/11/01.
-//
-
-import Foundation

--- a/BBus/BBus/Search/Model/StationSearchResult.swift
+++ b/BBus/BBus/Search/Model/StationSearchResult.swift
@@ -1,0 +1,14 @@
+//
+//  SearchBusModel.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/01.
+//
+
+import Foundation
+
+struct StationSearchResult {
+    let stationDTO: StationDTO
+    var arsIdMatchRange: [Range<String.Index>]
+    var stationNameMatchRange: [Range<String.Index>]
+}

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -64,7 +64,7 @@ class SearchViewController: UIViewController {
     }
     
     private func bindingBusResult() {
-        self.cancellable = self.viewModel?.$busSearchResult
+        self.cancellable = self.viewModel?.$busSearchResults
             .receive(on: SearchUseCase.thread)
             .sink(receiveValue: { _ in
                 DispatchQueue.main.async {
@@ -85,7 +85,7 @@ extension SearchViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.searchView.currentSearchType == SearchType.bus {
-            guard let busRouteId = self.viewModel?.busSearchResult[indexPath.row].routeID else { return }
+            guard let busRouteId = self.viewModel?.busSearchResults[indexPath.row].routeID else { return }
             self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
         }
         else {
@@ -99,12 +99,12 @@ extension SearchViewController: UICollectionViewDataSource {
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         let regionCount = 1
-        return self.viewModel?.busSearchResult.count == 0 ? 0 : regionCount
+        return self.viewModel?.busSearchResults.count == 0 ? 0 : regionCount
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView.frame.origin.x == 0 {
-            return self.viewModel?.busSearchResult.count ?? 0
+            return self.viewModel?.busSearchResults.count ?? 0
         }
         else {
             return 1
@@ -121,7 +121,7 @@ extension SearchViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.identifier, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
         if collectionView.frame.origin.x == 0 {
-            guard let bus = self.viewModel?.busSearchResult[indexPath.row] else { return UICollectionViewCell() }
+            guard let bus = self.viewModel?.busSearchResults[indexPath.row] else { return UICollectionViewCell() }
             cell.configureBusUI(title: bus.busRouteName, detailInfo: bus.routeType)
         }
         else {

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -85,7 +85,8 @@ extension SearchViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.searchView.currentSearchType == SearchType.bus {
-            self.coordinator?.pushToBusRoute()
+            guard let busRouteId = self.viewModel?.busSearchResult[indexPath.row].routeID else { return }
+            self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
         }
         else {
             self.coordinator?.pushToStation()

--- a/BBus/BBus/Search/UseCase/SearchUseCase.swift
+++ b/BBus/BBus/Search/UseCase/SearchUseCase.swift
@@ -63,4 +63,18 @@ class SearchUseCase {
             return routeList.filter { $0.busRouteName.hasPrefix(keyword) }
         }
     }
+    
+    func searchStation(by keyword: String) -> [StationSearchResult]? {
+        guard let stationList = self.stationList else { return nil }
+        
+        if keyword == "" {
+            return []
+        }
+        else {
+            return stationList.map { StationSearchResult(stationDTO: $0,
+                                                         arsIdMatchRange: $0.arsID.ranges(of: keyword),
+                                                         stationNameMatchRange: $0.stationName.ranges(of: keyword)) }
+                              .filter { !($0.arsIdMatchRange.isEmpty && $0.stationNameMatchRange.isEmpty) }
+        }
+    }
 }

--- a/BBus/BBus/Search/ViewModel/SearchViewModel.swift
+++ b/BBus/BBus/Search/ViewModel/SearchViewModel.swift
@@ -15,7 +15,8 @@ class SearchViewModel {
     private let usecase: SearchUseCase
     private var cancellables: Set<AnyCancellable>
     @Published private var keyword: String
-    @Published private(set) var busSearchResult: [BusRouteDTO] = []
+    @Published private(set) var busSearchResults: [BusRouteDTO] = []
+    @Published private(set) var stationSearchResults: [StationSearchResult] = []
     
     init(usecase: SearchUseCase) {
         self.usecase = usecase
@@ -36,11 +37,20 @@ class SearchViewModel {
                     .receive(on: SearchUseCase.thread)
                     .debounce(for: .milliseconds(400), scheduler: SearchUseCase.thread)
                     .sink { keyword in
-                        guard let busSearchResult = self.usecase.searchBus(by: keyword) else { return }
-                        self.busSearchResult = busSearchResult
+                        guard let busSearchResults = self.usecase.searchBus(by: keyword) else { return }
+                        self.busSearchResults = busSearchResults
                     }
                     .store(in: &self.cancellables)
             })
+            .store(in: &self.cancellables)
+        
+        self.$keyword
+            .receive(on: SearchUseCase.thread)
+            .debounce(for: .milliseconds(400), scheduler: SearchUseCase.thread)
+            .sink { keyword in
+                guard let stationSearchResults = self.usecase.searchStation(by: keyword) else { return }
+                self.stationSearchResults = stationSearchResults
+            }
             .store(in: &self.cancellables)
     }
 }

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -113,7 +113,7 @@ class StationViewController: UIViewController {
 // MARK: - Delegate : CollectionView
 extension StationViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.coordinator?.pushToBusRoute()
+        self.coordinator?.pushToBusRoute(busRouteId: 272)
     }
 }
 


### PR DESCRIPTION
close #65 

## 작업 내용
- [x] UseCase에 데이터를 가져오는 함수 작성
- [x] ViewModel에 usecase를 사용하여 데이터를 불러오는 로직 작성
- [x] 검색어를 바탕으로 Persistent Storage 내에 있는 정류소 json 데이터를 가져올 수 있어야 한다.

## 시연 방법

망원동 검색 예시

https://user-images.githubusercontent.com/70833900/141294226-0db50be6-9ea0-4c94-98cb-c1f03b323361.mov

## 기타 (고민과 해결, 리뷰 포인트 등)
- 문자열 내에서 키워드를 포함하고 있는 모든 부분들을 어떻게 찾을 것인가?
  - 문자열 내에서 x라는 문자열의 첫번째 등장 위치를 찾아 Range<String.Index>로 반환하는 메소드는 있음. `string.range(of:)`
  - 그러나 모든 등장 위치를 찾아 Range의 배열형태 `[Range<String.Index>]`로 반환하는 메소드는 없었음.
  - ->`extension String` 으로 직접 `ranges(of:) -> [Range<String.Index>]` 메소드를 구현해두었음.