### PR TITLE
[검색] 3-6. 얻어온 정거장의 이름 또는 번호와 일치하는 부분을 주황색으로 표시한다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04045B7F2740F6B30056A433 /* SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04045B7E2740F6B20056A433 /* SearchResults.swift */; };
 		04045B812740F6DC0056A433 /* BusSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04045B802740F6DC0056A433 /* BusSearchResult.swift */; };
 		041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041A5A10273D2E1B00490075 /* StringExtension.swift */; };
 		04214061273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */; };
@@ -117,6 +118,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04045B7E2740F6B20056A433 /* SearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResults.swift; sourceTree = "<group>"; };
 		04045B802740F6DC0056A433 /* BusSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusSearchResult.swift; sourceTree = "<group>"; };
 		041A5A10273D2E1B00490075 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusFoldUnfoldDelegate.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 		4ACA51ED272FCDD900EC0531 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				04045B7E2740F6B20056A433 /* SearchResults.swift */,
 				4ACA51EE272FCDE600EC0531 /* StationSearchResult.swift */,
 				04045B802740F6DC0056A433 /* BusSearchResult.swift */,
 			);
@@ -837,6 +840,7 @@
 				04AC7D1B2733E7270095CD4E /* AlarmSettingButton.swift in Sources */,
 				4A97C4D4273A822D00F1A765 /* Pushables.swift in Sources */,
 				049375BD273C2E120061ACDA /* ArrInfoByRouteDTO.swift in Sources */,
+				04045B7F2740F6B30056A433 /* SearchResults.swift in Sources */,
 				873D639A27303B0500E79069 /* HomeCoornicator.swift in Sources */,
 				4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */,
 				4ACA5213272FCE8500EC0531 /* StationModel.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04045B812740F6DC0056A433 /* BusSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04045B802740F6DC0056A433 /* BusSearchResult.swift */; };
 		041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041A5A10273D2E1B00490075 /* StringExtension.swift */; };
 		04214061273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */; };
 		0476ABBB27310ED200F72DD1 /* BusRouteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476ABBA27310ED200F72DD1 /* BusRouteHeaderView.swift */; };
@@ -116,6 +117,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04045B802740F6DC0056A433 /* BusSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusSearchResult.swift; sourceTree = "<group>"; };
 		041A5A10273D2E1B00490075 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusFoldUnfoldDelegate.swift; sourceTree = "<group>"; };
 		0476ABBA27310ED200F72DD1 /* BusRouteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteHeaderView.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA51EE272FCDE600EC0531 /* StationSearchResult.swift */,
+				04045B802740F6DC0056A433 /* BusSearchResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -838,6 +841,7 @@
 				4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */,
 				4ACA5213272FCE8500EC0531 /* StationModel.swift in Sources */,
 				04AC7D112733AF090095CD4E /* BusRouteTableViewCell.swift in Sources */,
+				04045B812740F6DC0056A433 /* BusSearchResult.swift in Sources */,
 				041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */,
 				87038A8E273C10480078EAE3 /* GetRouteInfoItemFetcher.swift in Sources */,
 				4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */,

--- a/BBus/BBus/Search/Model/BusSearchResult.swift
+++ b/BBus/BBus/Search/Model/BusSearchResult.swift
@@ -1,0 +1,20 @@
+//
+//  BusSearchResult.swift
+//  BBus
+//
+//  Created by 최수정 on 2021/11/14.
+//
+
+import Foundation
+
+struct BusSearchResult {
+    let routeID: Int
+    let busRouteName: String
+    let routeType: RouteType
+    
+    init(busRouteDTO: BusRouteDTO) {
+        self.routeID = busRouteDTO.routeID
+        self.busRouteName = busRouteDTO.busRouteName
+        self.routeType = busRouteDTO.routeType
+    }
+}

--- a/BBus/BBus/Search/Model/SearchResults.swift
+++ b/BBus/BBus/Search/Model/SearchResults.swift
@@ -1,0 +1,13 @@
+//
+//  SearchResult.swift
+//  BBus
+//
+//  Created by 최수정 on 2021/11/14.
+//
+
+import Foundation
+
+struct SearchResults {
+    var busSearchResults: [BusSearchResult]
+    var stationSearchResults: [StationSearchResult]
+}

--- a/BBus/BBus/Search/Model/StationSearchResult.swift
+++ b/BBus/BBus/Search/Model/StationSearchResult.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct StationSearchResult {
-    let stationDTO: StationDTO
-    var arsIdMatchRange: [Range<String.Index>]
-    var stationNameMatchRange: [Range<String.Index>]
+    let stationName: String
+    let arsId: String
+    var stationNameMatchRange: [NSRange]
+    var arsIdMatchRange: [NSRange]
 }

--- a/BBus/BBus/Search/Model/StationSearchResult.swift
+++ b/BBus/BBus/Search/Model/StationSearchResult.swift
@@ -10,6 +10,13 @@ import Foundation
 struct StationSearchResult {
     let stationName: String
     let arsId: String
-    var stationNameMatchRange: [NSRange]
-    var arsIdMatchRange: [NSRange]
+    let stationNameMatchRanges: [NSRange]
+    let arsIdMatchRanges: [NSRange]
+    
+    init(stationName: String, arsId: String, stationNameMatchRanges: [Range<String.Index>], arsIdMatchRanges: [Range<String.Index>]) {
+        self.stationName = stationName
+        self.arsId = arsId
+        self.stationNameMatchRanges = stationNameMatchRanges.map { NSRange($0, in: stationName) }
+        self.arsIdMatchRanges = arsIdMatchRanges.map { NSRange($0, in: arsId) }
+    }
 }

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -17,6 +17,7 @@ class SearchViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         self.configureLayout()
         self.configureUI()
         self.configureDelegate()
@@ -60,22 +61,7 @@ class SearchViewController: UIViewController {
     }
     
     private func binding() {
-        self.bindingBusResult()
-        self.bindingStationResult()
-    }
-    
-    private func bindingBusResult() {
-        self.cancellable = self.viewModel?.$busSearchResults
-            .receive(on: SearchUseCase.thread)
-            .sink(receiveValue: { _ in
-                DispatchQueue.main.async {
-                    self.searchView.reload()
-                }
-            })
-    }
-    
-    private func bindingStationResult() {
-        self.cancellable = self.viewModel?.$stationSearchResults
+        self.cancellable = self.viewModel?.$searchResults
             .receive(on: SearchUseCase.thread)
             .sink(receiveValue: { _ in
                 DispatchQueue.main.async {
@@ -85,6 +71,7 @@ class SearchViewController: UIViewController {
     }
 }
 
+// MARK: - Delegate : SearchBackButton
 extension SearchViewController: SearchBackButtonDelegate {
     func shouldNavigationPop() {
         self.coordinator?.terminate()
@@ -96,11 +83,11 @@ extension SearchViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.searchView.currentSearchType == SearchType.bus {
-            guard let busRouteId = self.viewModel?.busSearchResults[indexPath.row].routeID else { return }
+            guard let busRouteId = self.viewModel?.searchResults.busSearchResults[indexPath.row].routeID else { return }
             self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
         }
         else {
-            guard let arsId = self.viewModel?.stationSearchResults[indexPath.row].arsId else { return }
+            guard let arsId = self.viewModel?.searchResults.stationSearchResults[indexPath.row].arsId else { return }
             self.coordinator?.pushToStation(arsId: arsId)
         }
     }
@@ -113,19 +100,19 @@ extension SearchViewController: UICollectionViewDataSource {
         let regionCount = 1
         
         if collectionView.frame.origin.x == 0 {
-            return self.viewModel?.busSearchResults.count == 0 ? 0 : regionCount
+            return self.viewModel?.searchResults.busSearchResults.count == 0 ? 0 : regionCount
         }
         else {
-            return self.viewModel?.stationSearchResults.count == 0 ? 0 : regionCount
+            return self.viewModel?.searchResults.stationSearchResults.count == 0 ? 0 : regionCount
         }
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView.frame.origin.x == 0 {
-            return self.viewModel?.busSearchResults.count ?? 0
+            return self.viewModel?.searchResults.busSearchResults.count ?? 0
         }
         else {
-            return self.viewModel?.stationSearchResults.count ?? 0
+            return self.viewModel?.searchResults.stationSearchResults.count ?? 0
         }
     }
 
@@ -139,15 +126,15 @@ extension SearchViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.identifier, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
         if collectionView.frame.origin.x == 0 {
-            guard let bus = self.viewModel?.busSearchResults[indexPath.row] else { return UICollectionViewCell() }
+            guard let bus = self.viewModel?.searchResults.busSearchResults[indexPath.row] else { return UICollectionViewCell() }
             cell.configureBusUI(title: bus.busRouteName, detailInfo: bus.routeType)
         }
         else {
-            guard let station = self.viewModel?.stationSearchResults[indexPath.row] else { return UICollectionViewCell() }
+            guard let station = self.viewModel?.searchResults.stationSearchResults[indexPath.row] else { return UICollectionViewCell() }
             cell.configureStationUI(title: station.stationName,
-                                    titleMatchRange: station.stationNameMatchRange,
+                                    titleMatchRanges: station.stationNameMatchRanges,
                                     arsId: station.arsId,
-                                    arsIdMatchRange: station.arsIdMatchRange)
+                                    arsIdMatchRanges: station.arsIdMatchRanges)
         }
         cell.configureLayout()
         return cell
@@ -170,6 +157,7 @@ extension SearchViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
+// MARK: - Delegate : TextField
 extension SearchViewController: TextFieldDelegate {
     func shouldRefreshSearchResult(by keyword: String) {
         self.viewModel?.configure(keyword: keyword)

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -89,7 +89,7 @@ extension SearchViewController: UICollectionViewDelegate {
             self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
         }
         else {
-            guard let arsId = self.viewModel?.stationSearchResults[indexPath.row].stationDTO.arsID else { return }
+            guard let arsId = self.viewModel?.stationSearchResults[indexPath.row].arsId else { return }
             self.coordinator?.pushToStation(arsId: arsId)
         }
     }
@@ -133,7 +133,10 @@ extension SearchViewController: UICollectionViewDataSource {
         }
         else {
             guard let station = self.viewModel?.stationSearchResults[indexPath.row] else { return UICollectionViewCell() }
-            cell.configureStationUI(title: station.stationDTO.stationName, detailInfo: station.stationDTO.arsID)
+            cell.configureStationUI(title: station.stationName,
+                                    titleMatchRange: station.stationNameMatchRange,
+                                    arsId: station.arsId,
+                                    arsIdMatchRange: station.arsIdMatchRange)
         }
         cell.configureLayout()
         return cell

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -61,10 +61,21 @@ class SearchViewController: UIViewController {
     
     private func binding() {
         self.bindingBusResult()
+        self.bindingStationResult()
     }
     
     private func bindingBusResult() {
         self.cancellable = self.viewModel?.$busSearchResults
+            .receive(on: SearchUseCase.thread)
+            .sink(receiveValue: { _ in
+                DispatchQueue.main.async {
+                    self.searchView.reload()
+                }
+            })
+    }
+    
+    private func bindingStationResult() {
+        self.cancellable = self.viewModel?.$stationSearchResults
             .receive(on: SearchUseCase.thread)
             .sink(receiveValue: { _ in
                 DispatchQueue.main.async {

--- a/BBus/BBus/Search/UseCase/SearchUseCase.swift
+++ b/BBus/BBus/Search/UseCase/SearchUseCase.swift
@@ -71,10 +71,15 @@ class SearchUseCase {
             return []
         }
         else {
-            return stationList.map { StationSearchResult(stationDTO: $0,
-                                                         arsIdMatchRange: $0.arsID.ranges(of: keyword),
-                                                         stationNameMatchRange: $0.stationName.ranges(of: keyword)) }
-                              .filter { !($0.arsIdMatchRange.isEmpty && $0.stationNameMatchRange.isEmpty) }
+            return stationList.map { (station) in
+                let stationNameMatchRange = station.stationName.ranges(of: keyword).map { NSRange($0, in: station.stationName) }
+                let arsIdMatchRange = station.arsID.ranges(of: keyword).map { NSRange($0, in: station.arsID) }
+                return StationSearchResult(stationName: station.stationName,
+                                           arsId: station.arsID,
+                                           stationNameMatchRange: stationNameMatchRange,
+                                           arsIdMatchRange: arsIdMatchRange)
+                }
+                .filter { !($0.arsIdMatchRange.isEmpty && $0.stationNameMatchRange.isEmpty) }
         }
     }
 }

--- a/BBus/BBus/Search/UseCase/SearchUseCase.swift
+++ b/BBus/BBus/Search/UseCase/SearchUseCase.swift
@@ -54,13 +54,15 @@ class SearchUseCase {
             .store(in: &self.cancellables)
     }
     
-    func searchBus(by keyword: String) -> [BusRouteDTO]? {
+    func searchBus(by keyword: String) -> [BusSearchResult]? {
         guard let routeList = self.routeList else { return nil }
+        
         if keyword == "" {
             return []
         }
         else {
             return routeList.filter { $0.busRouteName.hasPrefix(keyword) }
+                            .map { BusSearchResult(busRouteDTO: $0) }
         }
     }
     
@@ -71,15 +73,11 @@ class SearchUseCase {
             return []
         }
         else {
-            return stationList.map { (station) in
-                let stationNameMatchRange = station.stationName.ranges(of: keyword).map { NSRange($0, in: station.stationName) }
-                let arsIdMatchRange = station.arsID.ranges(of: keyword).map { NSRange($0, in: station.arsID) }
-                return StationSearchResult(stationName: station.stationName,
-                                           arsId: station.arsID,
-                                           stationNameMatchRange: stationNameMatchRange,
-                                           arsIdMatchRange: arsIdMatchRange)
-                }
-                .filter { !($0.arsIdMatchRange.isEmpty && $0.stationNameMatchRange.isEmpty) }
+            return stationList.map { StationSearchResult(stationName: $0.stationName,
+                                                         arsId: $0.arsID,
+                                                         stationNameMatchRanges: $0.stationName.ranges(of: keyword),
+                                                         arsIdMatchRanges: $0.arsID.ranges(of: keyword)) }
+                              .filter { !($0.arsIdMatchRanges.isEmpty && $0.stationNameMatchRanges.isEmpty) }
         }
     }
 }

--- a/BBus/BBus/Search/View/SearchResultCollectionViewCell.swift
+++ b/BBus/BBus/Search/View/SearchResultCollectionViewCell.swift
@@ -78,15 +78,15 @@ class SearchResultCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configureStationUI(title: String, titleMatchRange: [NSRange], arsId: String, arsIdMatchRange: [NSRange]) {
+    func configureStationUI(title: String, titleMatchRanges: [NSRange], arsId: String, arsIdMatchRanges: [NSRange]) {
         let attributedTitle = NSMutableAttributedString(string: title)
-        titleMatchRange.forEach {
+        titleMatchRanges.forEach {
             attributedTitle.addAttributes([.foregroundColor:BBusColor.bbusSearchRed as Any], range: $0)
         }
         self.titleLabel.attributedText = attributedTitle
         
         let attributedArsId = NSMutableAttributedString(string: arsId)
-        arsIdMatchRange.forEach {
+        arsIdMatchRanges.forEach {
             attributedArsId.addAttributes([.foregroundColor:BBusColor.bbusSearchRed as Any], range: $0)
         }
         self.detailInfoLabel.attributedText = attributedArsId

--- a/BBus/BBus/Search/View/SearchResultCollectionViewCell.swift
+++ b/BBus/BBus/Search/View/SearchResultCollectionViewCell.swift
@@ -78,8 +78,17 @@ class SearchResultCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configureStationUI(title: String, detailInfo: String) {
-        self.titleLabel.text = title
-        self.detailInfoLabel.text = detailInfo
+    func configureStationUI(title: String, titleMatchRange: [NSRange], arsId: String, arsIdMatchRange: [NSRange]) {
+        let attributedTitle = NSMutableAttributedString(string: title)
+        titleMatchRange.forEach {
+            attributedTitle.addAttributes([.foregroundColor:BBusColor.bbusSearchRed as Any], range: $0)
+        }
+        self.titleLabel.attributedText = attributedTitle
+        
+        let attributedArsId = NSMutableAttributedString(string: arsId)
+        arsIdMatchRange.forEach {
+            attributedArsId.addAttributes([.foregroundColor:BBusColor.bbusSearchRed as Any], range: $0)
+        }
+        self.detailInfoLabel.attributedText = attributedArsId
     }
 }


### PR DESCRIPTION
## 작업 내용
- [x] AttributesText를 사용하여 range 범위는 다른 색상으로 표시
- [x] viewModel의 stationSearchResult와 collectionniew 바인딩 

## 시연 방법

![Simulator Screen Recording - iPhone 12 - 2021-11-13 at 23 49 53](https://user-images.githubusercontent.com/70833900/141648175-b2b4663e-fbd4-410f-969a-a91c9a6b870d.gif)

## 기타 (고민과 해결, 리뷰 포인트 등)
- NSMutableAttributedText에서 특정 range에만 attribute를 먹일 때 range 타입 이슈
  - string에서 특정 단어와 일치하는 모든 부분을 찾아내는 ranges(of: ) 메소드를 StringExtension 으로 구현해뒀었음.
  - range(of:) 함수의 리턴 타입이 Range<String.Index>여서 ranges(of:)도 [Range<String.Index>] 타입으로 리턴하도록 구현해뒀는데
  - NSMutableAttributedText에 addAttributes를 하려고 하니 range를 NSRange 타입으로 넘겨주어야 해서 타입이 일치하지 않는 이슈가 있었음.
  - 다음과 같은 해결방법이 있었는데,
    1. ranges(of:) 함수의 리턴타입을 [NSRange]로 변경
    2. UseCase 쪽에서 ranges(of:)함수를 사용한 뒤, [NSRange] 타입으로 변환하여 저장
  - NSString이 아닌 String의 Extension이기 때문에 [NSRange]으로 리턴하는 것보다는 변환해서 쓰는 것이 맞다고 생각하여 최종적으로 2번 방식으로 구현함.
- 컬렉션뷰와 뷰모델의 stationSearchResult를 바인딩하는 코드를 빼먹었는데도 잘 작동하는 이슈
  - 현재 사용자가 어느 검색모드에 있든 텍스트필드의 keyword가 바뀌면 버스와 정거장 모두 재검색을 하게 됨.
  - 버스와 정거장이 하나의 collectionView에 표시되어 있으므로 busSearchResult와 stationSearchResult 중 하나만 바인딩을 해도 문제가 없음.
  - 오히려 두 가지를 모두 바인딩 해두면 reload가 두 번 일어나게됨.
  - 하지만 버스와 정거장 중 한 가지만 특정해서 바인딩 하는 것은 부적절하다고 생각됨.
  - 두 가지 결과를 모두 포괄하는 searchResult가 있고, searchResult에 바인딩하도록 리팩토링함.