### PR TITLE
[버스 노선도 정보] 7-7. 버스 아이콘 좌측에 말풍선 아이콘으로 해당 버스 번호판 4자리와, 혼잡도를 표시한다.

### DIFF
--- a/BBus/BBus/Assets.xcassets/Color/bbusCongestionGood.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/Color/bbusCongestionGood.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.251",
+          "green" : "0.808",
+          "red" : "0.376"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/Color/bbusCongestionHigh.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/Color/bbusCongestionHigh.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.310",
+          "green" : "0.333",
+          "red" : "0.871"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/Assets.xcassets/Color/bbusCongestionNormal.colorset/Contents.json
+++ b/BBus/BBus/Assets.xcassets/Color/bbusCongestionNormal.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.267",
+          "green" : "0.769",
+          "red" : "0.929"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -125,6 +125,7 @@ class BusRouteViewController: UIViewController {
 
     private func binding() {
         self.bindingBusRouteHeaderResult()
+        self.bindingBusRouteBodyResult()
     }
 
     private func bindingBusRouteHeaderResult() {
@@ -149,6 +150,7 @@ class BusRouteViewController: UIViewController {
             .receive(on: BusRouteUsecase.thread)
             .sink(receiveValue: { _ in
                 DispatchQueue.main.async {
+                    dump(self.viewModel?.bodys)
                     self.busRouteView.reload()
                 }
             })

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -166,9 +166,13 @@ extension BusRouteViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: BusRouteTableViewCell.reusableID, for: indexPath) as? BusRouteTableViewCell else { return UITableViewCell() }
-        guard let stationItem = self.viewModel?.bodys[indexPath.row] else { return UITableViewCell() }
-        cell.configure(beforeColor: BBusColor.bbusTypeBlue,
-                       afterColor: BBusColor.bbusTypeBlue,
+        guard let bodys = self.viewModel?.bodys else { return UITableViewCell() }
+        let stationItem = bodys[indexPath.row]
+        let afterSpeed = indexPath.row+1 == bodys.count ? nil : bodys[indexPath.row+1].sectionSpeed
+        cell.configure(speed: stationItem.sectionSpeed,
+                       afterSpeed: afterSpeed,
+                       index: indexPath.row,
+                       count: self.viewModel?.bodys.count ?? 0,
                        title: stationItem.stationName,
                        description: "\(stationItem.arsId)  |  \(stationItem.beginTm)-\(stationItem.lastTm)",
                        type: stationItem.transYn != "Y" ? .waypoint : .uturn)

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -170,8 +170,8 @@ extension BusRouteViewController: UITableViewDataSource {
         cell.configure(beforeColor: BBusColor.bbusTypeBlue,
                        afterColor: BBusColor.bbusTypeBlue,
                        title: stationItem.stationName,
-                       description: "\(stationItem.arsId) | \(stationItem.beginTm)-\(stationItem.lastTm)",
-                       type: indexPath.item != 10 ? .waypoint : .uturn)
+                       description: "\(stationItem.arsId)  |  \(stationItem.beginTm)-\(stationItem.lastTm)",
+                       type: stationItem.transYn != "Y" ? .waypoint : .uturn)
         return cell
     }
 }

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -15,6 +15,7 @@ class BusRouteViewController: UIViewController {
     private lazy var busRouteView = BusRouteView()
     private let viewModel: BusRouteViewModel?
     private var cancellables: Set<AnyCancellable> = []
+    private var busTags: [BusTagView] = []
 
     private lazy var refreshButton: UIButton = {
         let radius: CGFloat = 25
@@ -33,7 +34,6 @@ class BusRouteViewController: UIViewController {
         self.binding()
         self.configureLayout()
         self.configureDelegate()
-        self.configureMOCKDATA()
     }
 
     init(viewModel: BusRouteViewModel) {
@@ -110,22 +110,24 @@ class BusRouteViewController: UIViewController {
         self.busRouteView.configureColor(to: color)
     }
 
-    private func configureMOCKDATA() {
+    private func configureBusTags(buses: [BusPosInfo]) {
+        self.busTags.forEach { $0.removeFromSuperview() }
+        self.busTags.removeAll()
 
-
-        for i in 1...20 {
-            let location = CGFloat.random(in: (0...19))
-            self.busRouteView.addBusTag(location: location,
-                                        busIcon: BBusImage.blueBusIcon,
-                                        busNumber: "6302",
-                                        busCongestion: "혼잡",
-                                        isLowFloor: i%2 == 0)
+        buses.forEach { bus in
+            let tag = self.busRouteView.createBusTag(location: bus.location,
+                                                     busIcon: BBusImage.blueBusIcon,
+                                                     busNumber: bus.number,
+                                                     busCongestion: bus.congestion.toString(),
+                                                     isLowFloor: bus.islower)
+            self.busTags.append(tag)
         }
     }
 
     private func binding() {
         self.bindingBusRouteHeaderResult()
         self.bindingBusRouteBodyResult()
+        self.bindingBusesPosInfo()
     }
 
     private func bindingBusRouteHeaderResult() {
@@ -148,9 +150,23 @@ class BusRouteViewController: UIViewController {
     private func bindingBusRouteBodyResult() {
         self.viewModel?.$bodys
             .receive(on: BusRouteUsecase.thread)
-            .sink(receiveValue: { _ in
+            .sink(receiveValue: { bodys in
                 DispatchQueue.main.async {
                     self.busRouteView.reload()
+                    self.busRouteView.configureTableViewHeight(count: bodys.count)
+                }
+            })
+            .store(in: &cancellables)
+    }
+
+    private func bindingBusesPosInfo() {
+        self.viewModel?.$buses
+            .receive(on: BusRouteUsecase.thread)
+            .sink(receiveCompletion: { error in
+                print(error)
+            }, receiveValue: { buses in
+                DispatchQueue.main.async {
+                    self.configureBusTags(buses: buses)
                 }
             })
             .store(in: &cancellables)

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -150,7 +150,6 @@ class BusRouteViewController: UIViewController {
             .receive(on: BusRouteUsecase.thread)
             .sink(receiveValue: { _ in
                 DispatchQueue.main.async {
-                    dump(self.viewModel?.bodys)
                     self.busRouteView.reload()
                 }
             })

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -143,12 +143,22 @@ class BusRouteViewController: UIViewController {
             })
             .store(in: &cancellables)
     }
+
+    private func bindingBusRouteBodyResult() {
+        self.viewModel?.$bodys
+            .receive(on: BusRouteUsecase.thread)
+            .sink(receiveValue: { _ in
+                DispatchQueue.main.async {
+                    self.busRouteView.reload()
+                }
+            })
+    }
 }
 
 // MARK: - DataSource : TableView
 extension BusRouteViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 20
+        return self.viewModel?.bodys.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -30,10 +30,10 @@ class BusRouteViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.binding()
         self.configureLayout()
         self.configureDelegate()
         self.configureMOCKDATA()
-        self.binding()
     }
 
     init(viewModel: BusRouteViewModel) {
@@ -154,6 +154,7 @@ class BusRouteViewController: UIViewController {
                     self.busRouteView.reload()
                 }
             })
+            .store(in: &cancellables)
     }
 }
 
@@ -165,41 +166,12 @@ extension BusRouteViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: BusRouteTableViewCell.reusableID, for: indexPath) as? BusRouteTableViewCell else { return UITableViewCell() }
-
-        let beforeColor: UIColor
-        if indexPath.item == 0 {
-            beforeColor = BBusColor.clear
-        }
-        else if indexPath.item % 3 == 0 {
-            beforeColor = BBusColor.green
-        }
-        else if indexPath.item % 3 == 1 {
-            beforeColor = BBusColor.red
-        }
-        else {
-            beforeColor = BBusColor.yellow
-        }
-        
-        let afterColor: UIColor
-        if indexPath.item == 19 {
-            afterColor = BBusColor.clear
-        }
-        else if indexPath.item % 3 == 0 {
-            afterColor = BBusColor.red
-        }
-        else if indexPath.item % 3 == 1 {
-            afterColor = BBusColor.yellow
-        }
-        else {
-            afterColor = BBusColor.green
-        }
-        
-        cell.configure(beforeColor: beforeColor,
-                       afterColor: afterColor,
-                       title: "면복동",
-                       description: "19283 | 04:00-23:50",
+        guard let stationItem = self.viewModel?.bodys[indexPath.row] else { return UITableViewCell() }
+        cell.configure(beforeColor: BBusColor.bbusTypeBlue,
+                       afterColor: BBusColor.bbusTypeBlue,
+                       title: stationItem.stationName,
+                       description: "\(stationItem.arsId) | \(stationItem.beginTm)-\(stationItem.lastTm)",
                        type: indexPath.item != 10 ? .waypoint : .uturn)
-
         return cell
     }
 }

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -14,6 +14,7 @@ class BusRouteUsecase {
     private let usecases: GetRouteListUsecase & GetStationsByRouteListUsecase & GetBusPosByRtidUsecase
     @Published var header: BusRouteDTO?
     @Published var bodys: [StationByRouteListDTO] = []
+    @Published var buses: [BusPosByRtidDTO] = []
     private var cancellables: Set<AnyCancellable> = []
     static let thread = DispatchQueue(label: "BusRoute")
 
@@ -58,7 +59,8 @@ class BusRouteUsecase {
                     print(error)
                 }
             } receiveValue: { busPosByRtidList in
-                print(String(data: busPosByRtidList, encoding: .utf8))
+                guard let result = BBusXMLParser().parse(dtoType: BusPosByRtidResult.self, xml: busPosByRtidList) else { return }
+                self.buses = result.body.itemList
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -13,7 +13,7 @@ class BusRouteUsecase {
     private let busRouteId: Int
     private let usecases: GetRouteListUsecase & GetStationsByRouteListUsecase
     @Published var header: BusRouteDTO?
-    @Published var bodys: StationByRouteResult?
+    @Published var bodys: [StationByRouteListDTO] = []
     private var cancellables: Set<AnyCancellable> = []
     static let thread = DispatchQueue(label: "BusRoute")
 
@@ -44,7 +44,8 @@ class BusRouteUsecase {
                     print(error)
                 }
             } receiveValue: { stationsByRouteList in
-                self.bodys = BBusXMLParser().parse(dtoType: StationByRouteResult.self, xml: stationsByRouteList)
+                guard let result = BBusXMLParser().parse(dtoType: StationByRouteResult.self, xml: stationsByRouteList) else { return }
+                self.bodys = result.body.itemList
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -11,13 +11,13 @@ import Combine
 class BusRouteUsecase {
 
     private let busRouteId: Int
-    private let usecases: GetRouteListUsecase & GetStationsByRouteListUsecase
+    private let usecases: GetRouteListUsecase & GetStationsByRouteListUsecase & GetBusPosByRtidUsecase
     @Published var header: BusRouteDTO?
     @Published var bodys: [StationByRouteListDTO] = []
     private var cancellables: Set<AnyCancellable> = []
     static let thread = DispatchQueue(label: "BusRoute")
 
-    init(usecases: GetRouteListUsecase & GetStationsByRouteListUsecase, busRouteId: Int) {
+    init(usecases: GetRouteListUsecase & GetStationsByRouteListUsecase & GetBusPosByRtidUsecase, busRouteId: Int) {
         self.busRouteId = busRouteId
         self.usecases = usecases
     }
@@ -46,6 +46,19 @@ class BusRouteUsecase {
             } receiveValue: { stationsByRouteList in
                 guard let result = BBusXMLParser().parse(dtoType: StationByRouteResult.self, xml: stationsByRouteList) else { return }
                 self.bodys = result.body.itemList
+            }
+            .store(in: &cancellables)
+    }
+
+    func fetchBusPosList() {
+        self.usecases.getBusPosByRtid(busRoutedId: "\(self.busRouteId)")
+            .receive(on: Self.thread)
+            .sink { error in
+                if case .failure(let error) = error {
+                    print(error)
+                }
+            } receiveValue: { busPosByRtidList in
+                print(String(data: busPosByRtidList, encoding: .utf8))
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
+++ b/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
@@ -49,7 +49,7 @@ class BusRouteTableViewCell: BusStationTableViewCell {
         }
     }
     
-    func configure(beforeColor: UIColor, afterColor: UIColor, title: String, description: String, type: BusRootCenterImageType) {
+    func configure(beforeColor: UIColor?, afterColor: UIColor?, title: String, description: String, type: BusRootCenterImageType) {
         super.configure(beforeColor: beforeColor,
                         afterColor: afterColor,
                         title: title,

--- a/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
+++ b/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
@@ -38,6 +38,7 @@ class BusRouteTableViewCell: BusStationTableViewCell {
                 super.centerImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 super.centerImageView.centerXAnchor.constraint(equalTo: super.beforeCongestionLineView.centerXAnchor)
             ])
+            super.backgroundColor = BBusColor.bbusLightGray
         case .uturn:
             self.centerImageView.image = BBusImage.stationCenterUturn
             NSLayoutConstraint.activate([
@@ -46,6 +47,7 @@ class BusRouteTableViewCell: BusStationTableViewCell {
                 super.centerImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 super.centerImageView.trailingAnchor.constraint(equalTo: super.beforeCongestionLineView.centerXAnchor, constant: uturmImageXaxisMargin)
             ])
+            super.backgroundColor = BBusColor.white
         }
     }
     

--- a/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
+++ b/BBus/BBus/BusRoute/View/BusRouteTableViewCell.swift
@@ -51,12 +51,50 @@ class BusRouteTableViewCell: BusStationTableViewCell {
         }
     }
     
-    func configure(beforeColor: UIColor?, afterColor: UIColor?, title: String, description: String, type: BusRootCenterImageType) {
-        super.configure(beforeColor: beforeColor,
-                        afterColor: afterColor,
+    func configure(speed: Int, afterSpeed: Int?, index: Int, count: Int, title: String, description: String, type: BusRootCenterImageType) {
+        let lineColors = self.configureLineColors(speed: speed,
+                                                  afterSpeed: afterSpeed,
+                                                 index: index,
+                                                 count: count)
+        super.configure(beforeColor: lineColors.beforeColor,
+                        afterColor: lineColors.afterColor,
                         title: title,
                         description: description)
         
         self.configureCenterImage(type: type)
+    }
+
+    func configureLineColors(speed: Int, afterSpeed: Int?, index: Int, count: Int) -> (beforeColor:  UIColor?, afterColor:  UIColor?) {
+        var beforeColor: UIColor?
+        var afterColor: UIColor?
+        if afterSpeed == nil {
+            beforeColor = self.configureLineColor(speed: speed)
+            afterColor = BBusColor.clear
+        }
+        else {
+            guard let afterSpeed = afterSpeed else { return (UIColor(), UIColor())}
+            if index == 0 {
+                beforeColor = BBusColor.clear
+                afterColor = self.configureLineColor(speed: afterSpeed)
+            } else {
+                beforeColor = self.configureLineColor(speed: speed)
+                afterColor = self.configureLineColor(speed: afterSpeed)
+            }
+        }
+        return (beforeColor, afterColor)
+    }
+
+    func configureLineColor(speed: Int) -> UIColor? {
+        let color: UIColor?
+        if speed <= 9 {
+            color = BBusColor.bbusCongestionHigh
+        }
+        else if speed <= 20 {
+            color = BBusColor.bbusCongestionNormal
+        }
+        else {
+            color = BBusColor.bbusCongestionGood
+        }
+        return color
     }
 }

--- a/BBus/BBus/BusRoute/View/BusRouteView.swift
+++ b/BBus/BBus/BusRoute/View/BusRouteView.swift
@@ -125,4 +125,8 @@ class BusRouteView: UIView {
             busTag.centerYAnchor.constraint(equalTo: self.busRouteTableView.topAnchor, constant: (BusRouteTableViewCell.cellHeight/2) + location*BusRouteTableViewCell.cellHeight)
         ])
     }
+
+    func reload() {
+        self.busRouteTableView.reloadData()
+    }
 }

--- a/BBus/BBus/BusRoute/View/BusRouteView.swift
+++ b/BBus/BBus/BusRoute/View/BusRouteView.swift
@@ -27,6 +27,7 @@ class BusRouteView: UIView {
         tableView.separatorColor = BBusColor.bbusLightGray
         return tableView
     }()
+    private var busRouteTableViewHeightConstraint: NSLayoutConstraint?
     
     convenience init() {
         self.init(frame: CGRect())
@@ -68,6 +69,8 @@ class BusRouteView: UIView {
         
         self.busRouteScrollContentsView.addSubview(self.busRouteTableView)
         self.busRouteTableView.translatesAutoresizingMaskIntoConstraints = false
+        self.busRouteTableViewHeightConstraint = self.busRouteTableView.heightAnchor.constraint(equalToConstant: CGFloat(8)*BusRouteTableViewCell.cellHeight)
+        self.busRouteTableViewHeightConstraint?.isActive = true
         NSLayoutConstraint.activate([
             self.busRouteTableView.leadingAnchor.constraint(equalTo: self.busRouteScrollContentsView.leadingAnchor),
             self.busRouteTableView.trailingAnchor.constraint(equalTo: self.busRouteScrollContentsView.trailingAnchor),
@@ -98,9 +101,10 @@ class BusRouteView: UIView {
     }
 
     func configureTableViewHeight(count: Int) {
-        NSLayoutConstraint.activate([
-            self.busRouteTableView.heightAnchor.constraint(equalToConstant: CGFloat(count)*BusRouteTableViewCell.cellHeight)
-        ])
+        if count > 0 {
+            self.busRouteTableViewHeightConstraint?.constant = CGFloat(count)*BusRouteTableViewCell.cellHeight
+            self.layoutIfNeeded()
+        }
     }
 
     func configureHeaderView(busType: String, busNumber: String, fromStation: String, toStation: String) {
@@ -111,7 +115,7 @@ class BusRouteView: UIView {
     }
 
     // MARK: - Create BusTag
-    func addBusTag(location: CGFloat, busIcon: UIImage?, busNumber: String, busCongestion: String, isLowFloor: Bool) {
+    func createBusTag(location: CGFloat, busIcon: UIImage?, busNumber: String, busCongestion: String, isLowFloor: Bool) -> BusTagView {
         let busTag = BusTagView()
         busTag.configure(busIcon: busIcon,
                          busNumber: busNumber,
@@ -124,6 +128,8 @@ class BusRouteView: UIView {
             busTag.leadingAnchor.constraint(equalTo: self.busRouteTableView.leadingAnchor, constant: 5),
             busTag.centerYAnchor.constraint(equalTo: self.busRouteTableView.topAnchor, constant: (BusRouteTableViewCell.cellHeight/2) + location*BusRouteTableViewCell.cellHeight)
         ])
+
+        return busTag
     }
 
     func reload() {

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -11,13 +11,12 @@ import Combine
 class BusRouteViewModel {
 
     private let usecase: BusRouteUsecase
-    private var cancellables: Set<AnyCancellable>
+    private var cancellables: Set<AnyCancellable> = []
     @Published var header: BusRouteDTO?
     @Published var bodys: [StationByRouteListDTO] = []
 
     init(usecase: BusRouteUsecase) {
         self.usecase = usecase
-        self.cancellables = []
         self.getHeaderInfo()
         self.getBodysInfo()
     }
@@ -39,7 +38,6 @@ class BusRouteViewModel {
             .sink { _ in
                 guard let bodys = self.usecase.bodys?.body.itemList else { return }
                 self.bodys = bodys
-                dump(bodys)
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -13,7 +13,7 @@ class BusRouteViewModel {
     private let usecase: BusRouteUsecase
     private var cancellables: Set<AnyCancellable>
     @Published var header: BusRouteDTO?
-    @Published var bodys: [StationByRouteListDTO]?
+    @Published var bodys: [StationByRouteListDTO] = []
 
     init(usecase: BusRouteUsecase) {
         self.usecase = usecase
@@ -37,7 +37,9 @@ class BusRouteViewModel {
         self.usecase.$bodys
             .receive(on: BusRouteUsecase.thread)
             .sink { _ in
-                self.bodys = self.usecase.bodys?.body.itemList
+                guard let bodys = self.usecase.bodys?.body.itemList else { return }
+                self.bodys = bodys
+                dump(bodys)
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -21,6 +21,7 @@ class BusRouteViewModel {
         self.bindingBodysInfo()
         self.usecase.searchHeader()
         self.usecase.fetchRouteList()
+        self.usecase.fetchBusPosList()
     }
 
     private func bindingHeaderInfo() {

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -17,28 +17,31 @@ class BusRouteViewModel {
 
     init(usecase: BusRouteUsecase) {
         self.usecase = usecase
-        self.getHeaderInfo()
-        self.getBodysInfo()
+        self.bindingHeaderInfo()
+        self.bindingBodysInfo()
+        self.usecase.searchHeader()
+        self.usecase.fetchRouteList()
     }
 
-    private func getHeaderInfo() {
-        self.usecase.searchHeader()
+    private func bindingHeaderInfo() {
         self.usecase.$header
             .receive(on: BusRouteUsecase.thread)
-            .sink { _ in
-                self.header = self.usecase.header
-            }
+            .sink(receiveCompletion: { error in
+                print(error)
+            }, receiveValue: { header in
+                self.header = header
+            })
             .store(in: &cancellables)
     }
 
-    private func getBodysInfo() {
-        self.usecase.fetchRouteList()
+    private func bindingBodysInfo() {
         self.usecase.$bodys
             .receive(on: BusRouteUsecase.thread)
-            .sink { _ in
-                guard let bodys = self.usecase.bodys?.body.itemList else { return }
+            .sink(receiveCompletion: { error in
+                print(error)
+            }, receiveValue: { bodys in
                 self.bodys = bodys
-            }
+            })
             .store(in: &cancellables)
     }
 }

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import CoreGraphics
 
 class BusRouteViewModel {
 
@@ -14,14 +15,18 @@ class BusRouteViewModel {
     private var cancellables: Set<AnyCancellable> = []
     @Published var header: BusRouteDTO?
     @Published var bodys: [StationByRouteListDTO] = []
+    @Published var buses: [BusPosByRtidDTO] = []
 
     init(usecase: BusRouteUsecase) {
         self.usecase = usecase
         self.bindingHeaderInfo()
         self.bindingBodysInfo()
+        self.bindingBusesPosInfo()
         self.usecase.searchHeader()
         self.usecase.fetchRouteList()
         self.usecase.fetchBusPosList()
+        print(self.convertBusPos(order: 3, sect: "0.079", fullSect: "0.236"))
+        print(self.busNumber(from: "서울74사6161"))
     }
 
     private func bindingHeaderInfo() {
@@ -45,4 +50,32 @@ class BusRouteViewModel {
             })
             .store(in: &cancellables)
     }
+
+    private func bindingBusesPosInfo() {
+        self.usecase.$buses
+            .receive(on: BusRouteUsecase.thread)
+            .sink(receiveCompletion: { error in
+                print(error)
+            }, receiveValue: { buses in
+                self.buses = buses
+            })
+            .store(in: &cancellables)
+    }
+
+    private func convertBusPos(order: Int, sect: String, fullSect: String) -> CGFloat {
+        let order = CGFloat(order-1)
+        let sect = CGFloat((sect as NSString).floatValue)
+        let fullSect = CGFloat((fullSect as NSString).floatValue)
+        return order + (sect/fullSect)
+    }
+
+    private func busNumber(from: String) -> String {
+        let startIndex = from.index(from.startIndex, offsetBy: 5)
+        let endIndex = from.endIndex
+        return String(from[startIndex..<endIndex])
+    }
 }
+// 1. 버스위치 변환
+// 2. 버스번호 추출
+// 3. 저상 변환
+// 4. 여유 변환

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -9,9 +9,9 @@ import Foundation
 import Combine
 import CoreGraphics
 
-class BusRouteViewModel {
+typealias BusPosInfo = (location: CGFloat, number: String, congestion: BusCongestion, islower: Bool)
 
-    typealias BusPosInfo = (location: CGFloat, number: String, congestion: BusCongestion, islower: Bool)
+class BusRouteViewModel {
 
     private let usecase: BusRouteUsecase
     private var cancellables: Set<AnyCancellable> = []
@@ -88,6 +88,5 @@ class BusRouteViewModel {
             busesResult.append(info)
         }
         self.buses = busesResult
-        dump(self.buses)
     }
 }

--- a/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -13,11 +13,13 @@ class BusRouteViewModel {
     private let usecase: BusRouteUsecase
     private var cancellables: Set<AnyCancellable>
     @Published var header: BusRouteDTO?
+    @Published var bodys: [StationByRouteListDTO]?
 
     init(usecase: BusRouteUsecase) {
         self.usecase = usecase
         self.cancellables = []
         self.getHeaderInfo()
+        self.getBodysInfo()
     }
 
     private func getHeaderInfo() {
@@ -26,6 +28,16 @@ class BusRouteViewModel {
             .receive(on: BusRouteUsecase.thread)
             .sink { _ in
                 self.header = self.usecase.header
+            }
+            .store(in: &cancellables)
+    }
+
+    private func getBodysInfo() {
+        self.usecase.fetchRouteList()
+        self.usecase.$bodys
+            .receive(on: BusRouteUsecase.thread)
+            .sink { _ in
+                self.bodys = self.usecase.bodys?.body.itemList
             }
             .store(in: &cancellables)
     }

--- a/BBus/BBus/Global/Constant/BBusColor.swift
+++ b/BBus/BBus/Global/Constant/BBusColor.swift
@@ -30,4 +30,7 @@ enum BBusColor {
     static let bbusLikeYellow = UIColor(named: "bbusLikeYellow")
     static let iconColor = UIColor(named: "bbusAlarmGray")
     static let alarmTint = UIColor(named: "bbusGray")
+    static let bbusCongestionHigh = UIColor(named: "bbusCongestionHigh")
+    static let bbusCongestionNormal = UIColor(named: "bbusCongestionNormal")
+    static let bbusCongestionGood = UIColor(named: "bbusCongestionGood")
 }

--- a/BBus/BBus/Global/DTO/BusPosByRtidDTO.swift
+++ b/BBus/BBus/Global/DTO/BusPosByRtidDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct BusPosByRtidBody: BBusXMLDTO {
-    private let itemList: [BusPosByRtidDTO]
+    let itemList: [BusPosByRtidDTO]
 
     init?(dict: [String : [Any]]) {
         guard let itemList = (dict["itemList"] as? [[String:[Any]]])?.map({ BusPosByRtidDTO(dict: $0) }),
@@ -38,6 +38,8 @@ struct BusPosByRtidDTO: BBusXMLDTO {
     let congestion: Int
     let plainNumber: String
     let sectionOrder: Int
+    let fullSectDist: String
+    let sectDist: String
     
     init?(dict: [String : [Any]]) {
         guard let busTypeString = ((dict["busType"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
@@ -46,11 +48,15 @@ struct BusPosByRtidDTO: BBusXMLDTO {
               let congestion = Int(congestionString),
               let plainNumber = ((dict["plainNo"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
               let sectOrd = ((dict["sectOrd"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
-              let sectionOrder = Int(sectOrd) else { return nil }
+              let sectionOrder = Int(sectOrd),
+              let fullSectDist = ((dict["fullSectDist"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
+              let sectDist = ((dict["sectDist"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }) else { return nil }
         
         self.busType = busType
         self.congestion = congestion
         self.plainNumber = plainNumber
         self.sectionOrder = sectionOrder
+        self.fullSectDist = fullSectDist
+        self.sectDist = sectDist
     }
 }

--- a/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
+++ b/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
@@ -40,6 +40,7 @@ struct StationByRouteListDTO: BBusXMLDTO {
     let fullSectionDistance: Int
     let arsId: String
     let beginTm: String
+    let lastTm: String
     
     init?(dict: [String : [Any]]) {
         guard let sectSpdString = ((dict["sectSpd"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
@@ -50,7 +51,8 @@ struct StationByRouteListDTO: BBusXMLDTO {
               let fullSectionDistanceString = ((dict["fullSectDist"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
               let fullSectionDistance = Int(fullSectionDistanceString),
               let arsId = ((dict["arsId"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
-              let beginTm = ((dict["beginTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}) else { return nil }
+              let beginTm = ((dict["beginTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}),
+              let lastTm = ((dict["lastTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}) else { return nil }
         
         self.sectionSpeed = sectSpd
         self.sequence = seq
@@ -58,5 +60,6 @@ struct StationByRouteListDTO: BBusXMLDTO {
         self.fullSectionDistance = fullSectionDistance
         self.arsId = arsId
         self.beginTm = beginTm
+        self.lastTm = lastTm
     }
 }

--- a/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
+++ b/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
@@ -39,6 +39,7 @@ struct StationByRouteListDTO: BBusXMLDTO {
     let stationName: String
     let fullSectionDistance: Int
     let arsId: String
+    let beginTm: String
     
     init?(dict: [String : [Any]]) {
         guard let sectSpdString = ((dict["sectSpd"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
@@ -48,12 +49,14 @@ struct StationByRouteListDTO: BBusXMLDTO {
               let stationName = ((dict["stationNm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
               let fullSectionDistanceString = ((dict["fullSectDist"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
               let fullSectionDistance = Int(fullSectionDistanceString),
-              let arsId = ((dict["arsId"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }) else { return nil }
+              let arsId = ((dict["arsId"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
+              let beginTm = ((dict["beginTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}) else { return nil }
         
         self.sectionSpeed = sectSpd
         self.sequence = seq
         self.stationName = stationName
         self.fullSectionDistance = fullSectionDistance
         self.arsId = arsId
+        self.beginTm = beginTm
     }
 }

--- a/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
+++ b/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct StationByRouteBody: BBusXMLDTO {
-    private let itemList: [StationByRouteListDTO]
+    let itemList: [StationByRouteListDTO]
 
     init?(dict: [String : [Any]]) {
         guard let itemList = (dict["itemList"] as? [[String:[Any]]])?.map({ StationByRouteListDTO(dict: $0) }),

--- a/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
+++ b/BBus/BBus/Global/DTO/StationByRouteListDTO.swift
@@ -41,6 +41,7 @@ struct StationByRouteListDTO: BBusXMLDTO {
     let arsId: String
     let beginTm: String
     let lastTm: String
+    let transYn: String
     
     init?(dict: [String : [Any]]) {
         guard let sectSpdString = ((dict["sectSpd"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
@@ -52,7 +53,8 @@ struct StationByRouteListDTO: BBusXMLDTO {
               let fullSectionDistance = Int(fullSectionDistanceString),
               let arsId = ((dict["arsId"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1 }),
               let beginTm = ((dict["beginTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}),
-              let lastTm = ((dict["lastTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}) else { return nil }
+              let lastTm = ((dict["lastTm"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}),
+              let transYn = ((dict["transYn"]?[0] as? [String:[Any]])?["bbus"] as? [String])?.reduce("", { $0 + $1}) else { return nil }
         
         self.sectionSpeed = sectSpd
         self.sequence = seq
@@ -61,5 +63,6 @@ struct StationByRouteListDTO: BBusXMLDTO {
         self.arsId = arsId
         self.beginTm = beginTm
         self.lastTm = lastTm
+        self.transYn = transYn
     }
 }

--- a/BBus/BBus/Global/Network/BBusAPIUsecases.swift
+++ b/BBus/BBus/Global/Network/BBusAPIUsecases.swift
@@ -29,7 +29,7 @@ class BBusAPIUsecases: RequestUsecases {
     }
 
     func getStationsByRouteList(busRoutedId: String) -> AnyPublisher<Data, Error> {
-        let param = ["busRoutedId": busRoutedId]
+        let param = ["busRouteId": busRoutedId]
         let fetcher: GetStationsByRouteListFetchable = ServiceGetStationsByRouteListFetcher()
         return fetcher.fetch(param: param, on: self.queue)
     }

--- a/BBus/BBus/Global/Network/BBusAPIUsecases.swift
+++ b/BBus/BBus/Global/Network/BBusAPIUsecases.swift
@@ -35,7 +35,7 @@ class BBusAPIUsecases: RequestUsecases {
     }
 
     func getBusPosByRtid(busRoutedId: String) -> AnyPublisher<Data, Error> {
-        let param = ["busRoutedId": busRoutedId]
+        let param = ["busRouteId": busRoutedId]
         let fetcher: GetBusPosByRtidFetchable = ServiceGetBusPosByRtidFetcher()
         return fetcher.fetch(param: param, on: self.queue)
     }

--- a/BBus/BBus/Global/Network/Fetcher/GetStationsByRouteListFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetStationsByRouteListFetcher.swift
@@ -14,7 +14,7 @@ protocol GetStationsByRouteListFetchable {
 
 class ServiceGetStationsByRouteListFetcher: GetStationsByRouteListFetchable {
     func fetch(param: [String : String], on queue: DispatchQueue) -> AnyPublisher<Data, Error> {
-        let url = "http://ws.bus.go.kr/api/rest/arrive/getArrInfoByRoute"
+        let url = "http://ws.bus.go.kr/api/rest/busRouteInfo/getStaionByRoute"
         return Service.shared.get(url: url, params: param, on: queue)
     }
 }


### PR DESCRIPTION
## 작업 내용
- [x] API를 통해 버스들의 위치정보를 받아온다
- [x] 받아온 Data를 XMLParser를 통해 DTO들로 변환한다
- [x] DTO 값들을 ViewController 에서 받아 이전 버스들을 제거한 후 하나씩 생성하여 넣는다
- [x] TableView의 높이를 bodys.count 개수에 맞도록 조정한다
- [x] 버스위치 DTO 정보에 따라 `busRouteView.createBusTag` 를 통해 tag 내용을 설정한다

## 시연 방법
<img src="https://user-images.githubusercontent.com/65349445/141649358-eea9bdbc-4835-41ee-a31b-9ca5c28cdf98.gif" width=700>

- BusRouteViewController 에서 binding 을 설정한다
- 버스 위치정보들이 수신되면 viewModel 에서 `BusPosInfo` 로 변환된 정보들을 ViewController 에서 수신한다
- 이전 tag 들을 모두 제거한 후 `busRouteView.createBusTag` 를 통해 태그 정보들을 넣어 생성한다


## 기타 (고민과 해결, 리뷰 포인트 등)
### BusTagView의 위치값 변환방법
- API 내에 있는 `sectionOrder, sectDist, fullSectDist` 값을 사용하여
- `(sectOrder-1) + (sectDist/fullSectDist)` 값을 통해 각 정거장 사이의 CGFloat의 Y 값을 얻을 수 있었다.
```Swift
private func convertBusPos(order: Int, sect: String, fullSect: String) -> CGFloat {
        let order = CGFloat(order-1)
        let sect = CGFloat((sect as NSString).floatValue)
        let fullSect = CGFloat((fullSect as NSString).floatValue)
        return order + (sect/fullSect)
    }
```
### BusTagView 들의 인스턴스 저장
- BusTagView의 경우 API의 새로운 정보값에 따라 제거되고 생성되어야 하는 구조이므로 인스턴스를 지녀야하며, 제거가 가능해야 한다.
- 따라서 BusRouteViewController 내에 `private var busTags: [BusTagView] = []` 변수를 생성하여 지니게끔 구현하였다.
- API 값이 바뀌게 되면 기존 Tag 들을 제거한 후 새로 생성하는 식으로 구현하였다.
```Swift
private func configureBusTags(buses: [BusPosInfo]) {
        self.busTags.forEach { $0.removeFromSuperview() }
        self.busTags.removeAll()

        buses.forEach { bus in
            let tag = self.busRouteView.createBusTag(location: bus.location,
                                                     busIcon: BBusImage.blueBusIcon,
                                                     busNumber: bus.number,
                                                     busCongestion: bus.congestion.toString(),
                                                     isLowFloor: bus.islower)
            self.busTags.append(tag)
        }
    }
```

### TableView 의 높이 조절
- BusTagView의 경우 스크롤되며 재사용되는 TableView 의 cell 과는 전혀 다르게 특정 origin 값에 위치하는 식으로 구현되었기 때문에
- TableView 높이 자체 또한 `cell의 높이 * 정거장 수` 이어야 했다.
- 따라서 이미 생성되어 있는 TableView 의 높이를 runTime 에 조정할 수 있어야 했다.
- 이러한 경우 NSLayoutConstraint 값을 상수로 따로 빼어야 하는 구조가 되어야 했다.
```Swift
private var busRouteTableViewHeightConstraint: NSLayoutConstraint?
```
```Swift
self.busRouteTableViewHeightConstraint = self.busRouteTableView.heightAnchor.constraint(equalToConstant: CGFloat(8)*BusRouteTableViewCell.cellHeight)
        self.busRouteTableViewHeightConstraint?.isActive = true
```
- 최종적으로 cell 의 개수만큼 조정되는 메소드를 이렇게 구현하였다
```Swift
func configureTableViewHeight(count: Int) {
        if count > 0 {
            self.busRouteTableViewHeightConstraint?.constant = CGFloat(count)*BusRouteTableViewCell.cellHeight
            self.layoutIfNeeded()
        }
```