### PR TITLE
[즐겨찾기] 14-3. 헤더를 누르면 알맞는 정거장 화면으로 이동한다.

### DIFF
--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -180,7 +180,6 @@ extension HomeViewController: AlarmButtonDelegate {
 // MARK: - FavoriteHeaderViewDelegate : UICollectionView
 extension HomeViewController: FavoriteHeaderViewDelegate {
     func shouldGoToStationScene(headerView: UICollectionReusableView) {
-
         guard let section = self.homeView.getSectionByHeaderView(header: headerView),
               let arsId = self.viewModel?.homeFavoriteList?[section]?.arsId else { return }
 

--- a/BBus/BBus/Home/View/FavoriteCollectionHeaderView.swift
+++ b/BBus/BBus/Home/View/FavoriteCollectionHeaderView.swift
@@ -25,8 +25,8 @@ class FavoriteCollectionHeaderView: UICollectionReusableView {
         }
     }
     
-    @objc private func headerViewTapped(_ sender: UICollectionReusableView) {
-        delegate?.shouldGoToStationScene(headerView: sender)
+    @objc private func headerViewTapped(_ sender: UITapGestureRecognizer) {
+        delegate?.shouldGoToStationScene(headerView: self)
     }
 
     private lazy var stationTitleLabel: UILabel = {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -90,9 +90,10 @@ class HomeView: UIView {
     }
 
     func getSectionByHeaderView(header: UICollectionReusableView) -> Int? {
-        guard let section = self.favoriteCollectionView.indexPathsForVisibleSupplementaryElements(ofKind: UICollectionView.elementKindSectionHeader).first(where: {
-            header == self.favoriteCollectionView.supplementaryView(forElementKind: UICollectionView.elementKindSectionHeader, at: $0)
-        })?.section else { return nil }
+        guard let section = self.favoriteCollectionView.indexPathsForVisibleSupplementaryElements(ofKind: UICollectionView.elementKindSectionHeader)
+                .first(where: { header == self.favoriteCollectionView.supplementaryView(forElementKind: UICollectionView.elementKindSectionHeader, at: $0) })?
+                .section else { return nil }
+        
         return section
     }
     


### PR DESCRIPTION
## 작업 내용
- [x] 컬렉션 뷰 헤더 터치 시 알맞은 정거장 화면으로 이동

## 시연 방법

![Simulator Screen Recording - iPhone 12 - 2021-11-16 at 14 29 18](https://user-images.githubusercontent.com/70833900/141926464-35e6a135-04db-4ef8-bc26-8dc6b621aa17.gif)

## 기타 (고민과 해결, 리뷰 포인트 등)
- tapGestureRecognizer의 action 함수에서 sender의 타입은 무엇으로 해야하는가?
  - 일단 맞는 타입은 `UITapGestureRecognizer`이다.
  - `sender: Any`로 받아서 출력해보면 UITapGestureRecognizer 타입이다.
  ``` Swift
    @objc private func headerViewTapped(_ sender: UITapGestureRecognizer) {
        delegate?.shouldGoToStationScene(headerView: self)
    }
  ```
  - 그런데 아래와 같이 `UICollectionViewReusableView` 타입으로 받아도 문제가 없다.???
  ``` Swift
    @objc private func headerViewTapped(_ sender: UICollectionViewReusableView) {
        delegate?.shouldGoToStationScene(headerView: self)
    }
  ```
  - 그래서 String 같이 전혀 관계없는 타입으로도 시도해보았다. 그 결과 `sender: String`으로 받는 것은 안된다.
  - 그래서 나온 추측:  action을 실행할 때 UITapGestureRecognizer를 AnyObject나 NSObject 같은 상위 타입으로 캐스팅해서 파라미터에 전달한다.
      -> 이 추측이 맞다면 print나 dump 했을 때 구체타입으로 출력이 안될텐데 되는 것을 보면 이건 아니다.

** 해결 못함 **

Close #141 