### PR TITLE
[승하차 알람] 9-2. 도착정보가 없으면 표시하지 않고, 남은 시간은 API가 보낸 메세지를 그대로 띄운다.2

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -36,8 +36,9 @@
 		4A04682A2732B7B3008D87CE /* SearchNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0468292732B7B3008D87CE /* SearchNavigationView.swift */; };
 		4A04682C2732ECAA008D87CE /* KeyboardAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682B2732ECA9008D87CE /* KeyboardAccessoryView.swift */; };
 		4A06AEC8274159D10027222D /* FavoriteItemDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A06AEC7274159D10027222D /* FavoriteItemDTO.swift */; };
-		4A094CE127438EB800428F55 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CE027438EB800428F55 /* UIViewExtension.swift */; };
 		4A094CDF27435C5900428F55 /* BusRemainTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CDE27435C5900428F55 /* BusRemainTime.swift */; };
+		4A094CE127438EB800428F55 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CE027438EB800428F55 /* UIViewExtension.swift */; };
+		4A094D072743E12C00428F55 /* NoneInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094D062743E12C00428F55 /* NoneInfoTableViewCell.swift */; };
 		4A17CED72733A754007B1646 /* SimpleCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17CED62733A754007B1646 /* SimpleCollectionHeaderView.swift */; };
 		4A17CED92733B5C6007B1646 /* SearchResultScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17CED82733B5C5007B1646 /* SearchResultScrollView.swift */; };
 		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
@@ -151,8 +152,9 @@
 		4A04682B2732ECA9008D87CE /* KeyboardAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAccessoryView.swift; sourceTree = "<group>"; };
 		4A06AEC2273E51AE0027222D /* AccessKey.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AccessKey.xcconfig; sourceTree = "<group>"; };
 		4A06AEC7274159D10027222D /* FavoriteItemDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteItemDTO.swift; sourceTree = "<group>"; };
-		4A094CE027438EB800428F55 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		4A094CDE27435C5900428F55 /* BusRemainTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRemainTime.swift; sourceTree = "<group>"; };
+		4A094CE027438EB800428F55 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
+		4A094D062743E12C00428F55 /* NoneInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneInfoTableViewCell.swift; sourceTree = "<group>"; };
 		4A17CED62733A754007B1646 /* SimpleCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCollectionHeaderView.swift; sourceTree = "<group>"; };
 		4A17CED82733B5C5007B1646 /* SearchResultScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultScrollView.swift; sourceTree = "<group>"; };
 		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
@@ -537,6 +539,7 @@
 				04AC7D122733B0940095CD4E /* GetOffTableViewCell.swift */,
 				87EB52AD2733A6C6000D5492 /* GetOnStatusCell.swift */,
 				04AC7D1A2733E7270095CD4E /* AlarmSettingButton.swift */,
+				4A094D062743E12C00428F55 /* NoneInfoTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */,
 				4ACA5225272FCEBF00EC0531 /* AlarmSettingView.swift in Sources */,
 				87038A92273C12320078EAE3 /* GetBusPosByRtidFetcher.swift in Sources */,
+				4A094D072743E12C00428F55 /* NoneInfoTableViewCell.swift in Sources */,
 				4ACA51E7272FCDA600EC0531 /* HomeViewModel.swift in Sources */,
 				4A1A22DD2732801700476861 /* StationCoodinator.swift in Sources */,
 				4ACA5237272FCF2C00EC0531 /* BusRouteViewController.swift in Sources */,

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -129,24 +129,24 @@ extension AlarmSettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case 0:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: GetOnStatusCell.reusableID, for: indexPath) as? GetOnStatusCell else { return UITableViewCell() }
-            guard let info = self.viewModel?.busArriveInfos[indexPath.row] else { return cell }
-            
-            cell.configure(busColor: BBusColor.bbusTypeBlue)
-            cell.configure(order: String(indexPath.row+1),
-                           remainingTime: info.arriveRemainTime?.toString(),
-                           remainingStationCount: info.relativePosition,
-                           busCongestionStatus: info.congestion?.toString(),
-                           arrivalTime: info.estimatedArrivalTime,
-                           currentLocation: info.currentStation,
-                           busNumber: info.plainNumber)
-            cell.configureDelegate(self)
-            
-            if info.arriveRemainTime == nil {
-                cell.configureNoneInfo(indexPath.row == 0)
+            guard let info = self.viewModel?.busArriveInfos[indexPath.row] else { return UITableViewCell() }
+            if (info.arriveRemainTime == nil && indexPath.row == 0) {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: NoneInfoTableViewCell.reusableID, for: indexPath) as? NoneInfoTableViewCell else { return UITableViewCell() }
+                return cell
             }
-            
-            return cell
+            else {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: GetOnStatusCell.reusableID, for: indexPath) as? GetOnStatusCell else { return UITableViewCell() }
+                cell.configure(busColor: BBusColor.bbusTypeBlue)
+                cell.configure(order: String(indexPath.row+1),
+                               remainingTime: info.arriveRemainTime?.toString(),
+                               remainingStationCount: info.relativePosition,
+                               busCongestionStatus: info.congestion?.toString(),
+                               arrivalTime: info.estimatedArrivalTime,
+                               currentLocation: info.currentStation,
+                               busNumber: info.plainNumber)
+                cell.configureDelegate(self)
+                return cell
+            }
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: GetOffTableViewCell.reusableID, for: indexPath) as? GetOffTableViewCell else { return UITableViewCell() }
             
@@ -182,7 +182,7 @@ extension AlarmSettingViewController: UITableViewDelegate {
             guard let info = self.viewModel?.busArriveInfos[indexPath.row] else { return 0 }
             switch info.arriveRemainTime {
             case nil :
-                return indexPath.row == 0 ? GetOnStatusCell.noneInfoCellHeight : GetOnStatusCell.singleInfoCellHeight
+                return indexPath.row == 0 ? NoneInfoTableViewCell.height : GetOnStatusCell.singleInfoCellHeight
             default :
                 return GetOnStatusCell.infoCellHeight
             }

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -117,7 +117,8 @@ extension AlarmSettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0:
-            return self.viewModel?.busArriveInfos.count ?? 0
+            guard let info = self.viewModel?.busArriveInfos.first else { return 0 }
+            return info.arriveRemainTime != nil ? (self.viewModel?.busArriveInfos.count ?? 0) : 1
         case 1:
             return 10
         default:
@@ -140,6 +141,11 @@ extension AlarmSettingViewController: UITableViewDataSource {
                            currentLocation: info.currentStation,
                            busNumber: info.plainNumber)
             cell.configureDelegate(self)
+            
+            if info.arriveRemainTime == nil {
+                cell.configureNoneInfo(indexPath.row == 0)
+            }
+            
             return cell
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: GetOffTableViewCell.reusableID, for: indexPath) as? GetOffTableViewCell else { return UITableViewCell() }
@@ -174,7 +180,12 @@ extension AlarmSettingViewController: UITableViewDelegate {
         switch indexPath.section {
         case 0:
             guard let info = self.viewModel?.busArriveInfos[indexPath.row] else { return 0 }
-            return info.arriveRemainTime != nil ? GetOnStatusCell.infoCellHeight : GetOnStatusCell.noInfoCellHeight
+            switch info.arriveRemainTime {
+            case nil :
+                return indexPath.row == 0 ? GetOnStatusCell.noneInfoCellHeight : GetOnStatusCell.singleInfoCellHeight
+            default :
+                return GetOnStatusCell.infoCellHeight
+            }
         case 1:
             return GetOffTableViewCell.cellHeight
         default:

--- a/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
+++ b/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
@@ -19,6 +19,7 @@ class AlarmSettingView: UIView {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.register(GetOffTableViewCell.self, forCellReuseIdentifier: GetOffTableViewCell.reusableID)
         tableView.register(GetOnStatusCell.self, forCellReuseIdentifier: GetOnStatusCell.reusableID)
+        tableView.register(NoneInfoTableViewCell.self, forCellReuseIdentifier: NoneInfoTableViewCell.reusableID)
         tableView.separatorStyle = .none
         tableView.backgroundColor = BBusColor.bbusBackground
         tableView.contentInset = UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 0)

--- a/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
+++ b/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
@@ -16,7 +16,6 @@ class GetOnStatusCell: UITableViewCell {
     static let reusableID = "GetOnStatusCell"
     static let infoCellHeight: CGFloat = 115
     static let singleInfoCellHeight: CGFloat = 50
-    static let noneInfoCellHeight: CGFloat = 130
 
     private lazy var busOrderNumberLabel: UILabel = {
         let labelFontSize: CGFloat = 8
@@ -131,26 +130,6 @@ class GetOnStatusCell: UITableViewCell {
         label.font = UIFont.systemFont(ofSize: labelFontSize)
         return label
     }()
-    private lazy var noInfoView: UIView = {
-        let view = UIView()
-        let noInfoImageView = UIImageView(image: BBusImage.info)
-        noInfoImageView.tintColor = BBusColor.bbusGray
-        let noInfoMessageLabel = UILabel()
-        noInfoMessageLabel.text = "도착예정 정보없음"
-        noInfoMessageLabel.textColor = BBusColor.bbusGray
-        view.addSubviews(noInfoImageView, noInfoMessageLabel)
-        
-        NSLayoutConstraint.activate([
-            noInfoImageView.bottomAnchor.constraint(equalTo: view.centerYAnchor),
-            noInfoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-        ])
-        NSLayoutConstraint.activate([
-            noInfoMessageLabel.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 10),
-            noInfoMessageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-        ])
-        view.isHidden = true
-        return view
-    }()
 
     private var alarmButtonDelegate: GetOnAlarmButtonDelegate? {
         didSet {
@@ -201,7 +180,7 @@ class GetOnStatusCell: UITableViewCell {
         let indicatorLabelLeadingAnchor: CGFloat = 5
         let separatorHeight: CGFloat = 1
 
-        self.addSubviews(self.busOrderNumberLabel, self.remainingTimeLabel, self.busStatusTagStackView, self.clockIconImageView, self.arrivalTimeLabel, self.locationIconImageView, self.currentLocationLabel, self.busIconImageView, self.busOrderNumberLabel, self.busNumberLabel, self.alarmButton, self.separatorView, self.noInfoMessageLabel, self.noInfoView)
+        self.addSubviews(self.busOrderNumberLabel, self.remainingTimeLabel, self.busStatusTagStackView, self.clockIconImageView, self.arrivalTimeLabel, self.locationIconImageView, self.currentLocationLabel, self.busIconImageView, self.busOrderNumberLabel, self.busNumberLabel, self.alarmButton, self.separatorView, self.noInfoMessageLabel)
         
         NSLayoutConstraint.activate([
             self.busOrderNumberLabel.widthAnchor.constraint(equalToConstant: busColorViewWidthAnchor),
@@ -274,13 +253,6 @@ class GetOnStatusCell: UITableViewCell {
             self.noInfoMessageLabel.centerYAnchor.constraint(equalTo: self.busOrderNumberLabel.centerYAnchor),
             self.noInfoMessageLabel.leadingAnchor.constraint(equalTo: self.busOrderNumberLabel.trailingAnchor, constant: termBusColorViewToRemainingTimeLabel)
         ])
-        
-        NSLayoutConstraint.activate([
-            self.noInfoView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.noInfoView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.noInfoView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.noInfoView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-        ])
     }
 
     func configure(busColor: UIColor?) {
@@ -309,12 +281,6 @@ class GetOnStatusCell: UITableViewCell {
         self.arrivalTimeLabel.text = arrivalTime
         self.currentLocationLabel.text = currentLocation
         self.busNumberLabel.text = busNumber
-    }
-    
-    func configureNoneInfo(_ isHidden: Bool) {
-        self.busOrderNumberLabel.isHidden = isHidden
-        self.noInfoMessageLabel.isHidden = isHidden
-        self.noInfoView.isHidden = !isHidden
     }
 
     func configureDelegate(_ delegate: GetOnAlarmButtonDelegate) {

--- a/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
+++ b/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
@@ -15,7 +15,8 @@ class GetOnStatusCell: UITableViewCell {
 
     static let reusableID = "GetOnStatusCell"
     static let infoCellHeight: CGFloat = 115
-    static let noInfoCellHeight: CGFloat = 50
+    static let singleInfoCellHeight: CGFloat = 50
+    static let noneInfoCellHeight: CGFloat = 130
 
     private lazy var busOrderNumberLabel: UILabel = {
         let labelFontSize: CGFloat = 8
@@ -130,6 +131,26 @@ class GetOnStatusCell: UITableViewCell {
         label.font = UIFont.systemFont(ofSize: labelFontSize)
         return label
     }()
+    private lazy var noInfoView: UIView = {
+        let view = UIView()
+        let noInfoImageView = UIImageView(image: BBusImage.info)
+        noInfoImageView.tintColor = BBusColor.bbusGray
+        let noInfoMessageLabel = UILabel()
+        noInfoMessageLabel.text = "도착예정 정보없음"
+        noInfoMessageLabel.textColor = BBusColor.bbusGray
+        view.addSubviews(noInfoImageView, noInfoMessageLabel)
+        
+        NSLayoutConstraint.activate([
+            noInfoImageView.bottomAnchor.constraint(equalTo: view.centerYAnchor),
+            noInfoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            noInfoMessageLabel.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 10),
+            noInfoMessageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+        view.isHidden = true
+        return view
+    }()
 
     private var alarmButtonDelegate: GetOnAlarmButtonDelegate? {
         didSet {
@@ -180,7 +201,7 @@ class GetOnStatusCell: UITableViewCell {
         let indicatorLabelLeadingAnchor: CGFloat = 5
         let separatorHeight: CGFloat = 1
 
-        self.addSubviews(self.busOrderNumberLabel, self.remainingTimeLabel, self.busStatusTagStackView, self.clockIconImageView, self.arrivalTimeLabel, self.locationIconImageView, self.currentLocationLabel, self.busIconImageView, self.busOrderNumberLabel, self.busNumberLabel, self.alarmButton, self.separatorView, self.noInfoMessageLabel)
+        self.addSubviews(self.busOrderNumberLabel, self.remainingTimeLabel, self.busStatusTagStackView, self.clockIconImageView, self.arrivalTimeLabel, self.locationIconImageView, self.currentLocationLabel, self.busIconImageView, self.busOrderNumberLabel, self.busNumberLabel, self.alarmButton, self.separatorView, self.noInfoMessageLabel, self.noInfoView)
         
         NSLayoutConstraint.activate([
             self.busOrderNumberLabel.widthAnchor.constraint(equalToConstant: busColorViewWidthAnchor),
@@ -253,6 +274,13 @@ class GetOnStatusCell: UITableViewCell {
             self.noInfoMessageLabel.centerYAnchor.constraint(equalTo: self.busOrderNumberLabel.centerYAnchor),
             self.noInfoMessageLabel.leadingAnchor.constraint(equalTo: self.busOrderNumberLabel.trailingAnchor, constant: termBusColorViewToRemainingTimeLabel)
         ])
+        
+        NSLayoutConstraint.activate([
+            self.noInfoView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.noInfoView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.noInfoView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.noInfoView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
     }
 
     func configure(busColor: UIColor?) {
@@ -281,6 +309,12 @@ class GetOnStatusCell: UITableViewCell {
         self.arrivalTimeLabel.text = arrivalTime
         self.currentLocationLabel.text = currentLocation
         self.busNumberLabel.text = busNumber
+    }
+    
+    func configureNoneInfo(_ isHidden: Bool) {
+        self.busOrderNumberLabel.isHidden = isHidden
+        self.noInfoMessageLabel.isHidden = isHidden
+        self.noInfoView.isHidden = !isHidden
     }
 
     func configureDelegate(_ delegate: GetOnAlarmButtonDelegate) {

--- a/BBus/BBus/AlarmSetting/View/NoneInfoTableViewCell.swift
+++ b/BBus/BBus/AlarmSetting/View/NoneInfoTableViewCell.swift
@@ -1,0 +1,50 @@
+//
+//  NoneInfoTableViewCell.swift
+//  BBus
+//
+//  Created by 이지수 on 2021/11/16.
+//
+
+import UIKit
+
+class NoneInfoTableViewCell: UITableViewCell {
+    
+    static let reusableID = "NoneInfoTableViewCell"
+    static let height: CGFloat = 130
+
+    private lazy var noInfoImageView: UIImageView = {
+        let imageView = UIImageView(image: BBusImage.info)
+        imageView.tintColor = BBusColor.bbusGray
+        return imageView
+    }()
+    private lazy var noInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "도착예정 정보없음"
+        label.textColor = BBusColor.bbusGray
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureLayout()
+    }
+    
+    private func configureLayout() {
+        self.addSubviews(self.noInfoImageView, self.noInfoLabel)
+        
+        NSLayoutConstraint.activate([
+            self.noInfoImageView.bottomAnchor.constraint(equalTo: self.centerYAnchor),
+            self.noInfoImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            self.noInfoLabel.topAnchor.constraint(equalTo: self.centerYAnchor, constant: 10),
+            self.noInfoLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ])
+    }
+}

--- a/BBus/BBus/Global/Constant/BBusImage.swift
+++ b/BBus/BBus/Global/Constant/BBusImage.swift
@@ -25,6 +25,10 @@ enum BBusImage {
         let largeConfig = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .large)
         return UIImage(systemName: "star.fill", withConfiguration: largeConfig)
     }()
+    static let info: UIImage? = {
+        let largeConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .large)
+        return UIImage(systemName: "info.circle", withConfiguration: largeConfig)
+    }()
     static let booDuck = UIImage(named: "booDuck")
     static let unfold = UIImage(systemName: "chevron.up")
     static let fold = UIImage(systemName: "chevron.down")

--- a/BBus/BBus/Global/Network/AccessKey.xcconfig
+++ b/BBus/BBus/Global/Network/AccessKey.xcconfig
@@ -8,7 +8,5 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-API_ACCESS_KEY = aaa
-API_ACCESS_KEY2 = aaa
-API_ACCESS_KEY3 = ""
-API_ACCESS_KEY4 = ""
+API_ACCESS_KEY2 = uAtMsUVNMLIM%2FM9jsvgC%2Fo%2BAPgjDeFWWYodCR7fEwEPCk4%2FHvHZRpKXLdvTXgcNA0GTPtfYIptCaFrqnzWqQLQ%3D%3D
+API_ACCESS_KEY = JU6Py4AWpotO1SCyjd0bbC9UbIYKLnFBmC9UJrQ6w9FLmBM4YvZROJndyYOxzQqlgDt5iWMcDWXKJWfe8%2F0xMw%3D%3D

--- a/BBus/BBus/Global/Network/Service.swift
+++ b/BBus/BBus/Global/Network/Service.swift
@@ -16,13 +16,12 @@ enum NetworkError: Error {
 class Service {
     static let shared = Service()
     
-    private let accessKey = (Bundle.main.infoDictionary?["API_ACCESS_KEY"] as? String)?.removingPercentEncoding
+    private let accessKey = (Bundle.main.infoDictionary?["API_ACCESS_KEY"] as? String)
     
     private init() { }
     
     func get(url: String, params: [String: String], on queue: DispatchQueue) -> AnyPublisher<Data, Error> {
         let publisher = PassthroughSubject<Data, Error>()
-        
         queue.async { [weak self, weak publisher] in
             guard let self = self else { return }
             guard let accessKey = self.accessKey else {
@@ -33,11 +32,14 @@ class Service {
                 publisher?.send(completion: .failure(NetworkError.urlError))
                 return
             }
-            var items: [URLQueryItem] = [URLQueryItem(name: "serviceKey", value: accessKey)]
+            var items: [URLQueryItem] = []
             params.forEach() { item in
                 items.append(URLQueryItem(name: item.key, value: item.value))
             }
             components.queryItems = items
+            if let query = components.percentEncodedQuery  {
+                components.percentEncodedQuery = query + "&serviceKey=" + accessKey
+            }
             
             if let url = components.url {
                 var request = URLRequest(url: url)


### PR DESCRIPTION
## 작업 내용
- [x] 도착 정보가 두개 온 경우 정보 표시
- [x] 도착 정보가 하나 온 경우, 두번째 셀은 도착정보 없음으로 표시
- [x] 도착 정보가 안 온 경우, 도착 예정 정보 없음으로 하나의 셀로 표시
## 시연 방법
1. 도착 정보가 두개 온 경우 
2. 도착 정보가 하나 온 경우
3. 도착 정보가 안 온 경우
를 순서대로 보여주고 있음

![Simulator Screen Recording - iPhone 12 - 2021-11-16 at 21 44 20](https://user-images.githubusercontent.com/64150179/141993953-48243a43-0a66-4ec2-9622-8890e983ee69.gif)

## 기타 (고민과 해결, 리뷰 포인트 등)
### GetOnStatusCell에 로직 추가 vs 새로운 Cell 생성
처음에는 GetOnStatusCell에 아래 버튼, 라벨을 표시시켜 isHidden으로 처리해주었으나
<img width="343" alt="스크린샷 2021-11-16 오후 10 29 54" src="https://user-images.githubusercontent.com/64150179/141994232-6c93840a-1096-40ea-8979-ded810a618ab.png">
GetOnStatusCell에 해당 로직이 있으면 GetOnStatusCell 내부 isHidden 로직이 복잡해져 아무 정보도 없을 경우 뜨는 TableViewCell은 NoneInfoTableViewCell로 완전히 분리시켜 주었습니다.
그러고나니 로직이 보다 깔끔해졌습니다. 

close #105 