### PR TITLE
[갱신] 17-1. 남은 정류소 시간을 보여주는 모든 화면에 대해 1초 간격으로 줄어드는 뷰를 보여준다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -36,8 +36,9 @@
 		4A04682A2732B7B3008D87CE /* SearchNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0468292732B7B3008D87CE /* SearchNavigationView.swift */; };
 		4A04682C2732ECAA008D87CE /* KeyboardAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682B2732ECA9008D87CE /* KeyboardAccessoryView.swift */; };
 		4A06AEC8274159D10027222D /* FavoriteItemDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A06AEC7274159D10027222D /* FavoriteItemDTO.swift */; };
-		4A094CE127438EB800428F55 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CE027438EB800428F55 /* UIViewExtension.swift */; };
+		4A06AEE92743DAB20027222D /* NotificationNameExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A06AEE82743DAB20027222D /* NotificationNameExtension.swift */; };
 		4A094CDF27435C5900428F55 /* BusRemainTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CDE27435C5900428F55 /* BusRemainTime.swift */; };
+		4A094CE127438EB800428F55 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A094CE027438EB800428F55 /* UIViewExtension.swift */; };
 		4A17CED72733A754007B1646 /* SimpleCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17CED62733A754007B1646 /* SimpleCollectionHeaderView.swift */; };
 		4A17CED92733B5C6007B1646 /* SearchResultScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17CED82733B5C5007B1646 /* SearchResultScrollView.swift */; };
 		4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A22DA27326FD100476861 /* HomeNavigationView.swift */; };
@@ -151,8 +152,9 @@
 		4A04682B2732ECA9008D87CE /* KeyboardAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAccessoryView.swift; sourceTree = "<group>"; };
 		4A06AEC2273E51AE0027222D /* AccessKey.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AccessKey.xcconfig; sourceTree = "<group>"; };
 		4A06AEC7274159D10027222D /* FavoriteItemDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteItemDTO.swift; sourceTree = "<group>"; };
-		4A094CE027438EB800428F55 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
+		4A06AEE82743DAB20027222D /* NotificationNameExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNameExtension.swift; sourceTree = "<group>"; };
 		4A094CDE27435C5900428F55 /* BusRemainTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRemainTime.swift; sourceTree = "<group>"; };
+		4A094CE027438EB800428F55 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		4A17CED62733A754007B1646 /* SimpleCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCollectionHeaderView.swift; sourceTree = "<group>"; };
 		4A17CED82733B5C5007B1646 /* SearchResultScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultScrollView.swift; sourceTree = "<group>"; };
 		4A1A22DA27326FD100476861 /* HomeNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationView.swift; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 			children = (
 				041A5A10273D2E1B00490075 /* StringExtension.swift */,
 				4A094CE027438EB800428F55 /* UIViewExtension.swift */,
+				4A06AEE82743DAB20027222D /* NotificationNameExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -871,6 +874,7 @@
 				4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */,
 				4A1A22E12732CE7900476861 /* SearchResultCollectionViewCell.swift in Sources */,
 				87EB52AE2733A6C6000D5492 /* GetOnStatusCell.swift in Sources */,
+				4A06AEE92743DAB20027222D /* NotificationNameExtension.swift in Sources */,
 				4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */,
 				4A7BBFED2737885F0029915F /* StationHeaderView.swift in Sources */,
 				049375B5273BB98E0061ACDA /* StationByRouteListDTO.swift in Sources */,

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -100,9 +100,11 @@ class AlarmSettingViewController: UIViewController {
     
     private func bindingBusArriveInfos() {
         self.viewModel?.$busArriveInfos
-            .receive(on: DispatchQueue.main)
+            .throttle(for: .seconds(1), scheduler: AlarmSettingUseCase.queue, latest: true)
             .sink(receiveValue: { [weak self] data in
-                self?.alarmSettingView.reload()
+                DispatchQueue.main.async {
+                    self?.alarmSettingView.reload()
+                }
             })
             .store(in: &self.cancellables)
     }

--- a/BBus/BBus/AlarmSetting/Model/AlarmSettingBusArriveInfo.swift
+++ b/BBus/BBus/AlarmSetting/Model/AlarmSettingBusArriveInfo.swift
@@ -16,7 +16,7 @@ struct AlarmSettingBusArriveInfo {
         return formatter
     }()
     
-    let arriveRemainTime: BusRemainTime?
+    var arriveRemainTime: BusRemainTime?
     let estimatedArrivalTime: String?
     let relativePosition: String?
     let congestion: BusCongestion?

--- a/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -26,6 +26,21 @@ class AlarmSettingViewModel {
         self.busArriveInfos = []
         self.bindingBusArriveInfo()
         self.refresh()
+        self.configureObserver()
+    }
+    
+    private func configureObserver() {
+        NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
+            self.descendTime()
+        }
+    }
+    
+    private func descendTime() {
+        self.busArriveInfos = self.busArriveInfos.map {
+            var arriveInfo = $0
+            arriveInfo.arriveRemainTime?.descend()
+            return arriveInfo
+        }
     }
     
     func refresh() {

--- a/BBus/BBus/Global/Extension/NotificationNameExtension.swift
+++ b/BBus/BBus/Global/Extension/NotificationNameExtension.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationNameExtension.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/16.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let oneSecondPassed = Self.init(rawValue: "oneSecondPassed")
+}

--- a/BBus/BBus/Global/Network/Service.swift
+++ b/BBus/BBus/Global/Network/Service.swift
@@ -16,13 +16,12 @@ enum NetworkError: Error {
 class Service {
     static let shared = Service()
     
-    private let accessKey = (Bundle.main.infoDictionary?["API_ACCESS_KEY"] as? String)?.removingPercentEncoding
+    private let accessKey = (Bundle.main.infoDictionary?["API_ACCESS_KEY"] as? String)
     
     private init() { }
     
     func get(url: String, params: [String: String], on queue: DispatchQueue) -> AnyPublisher<Data, Error> {
         let publisher = PassthroughSubject<Data, Error>()
-        
         queue.async { [weak self, weak publisher] in
             guard let self = self else { return }
             guard let accessKey = self.accessKey else {
@@ -33,11 +32,14 @@ class Service {
                 publisher?.send(completion: .failure(NetworkError.urlError))
                 return
             }
-            var items: [URLQueryItem] = [URLQueryItem(name: "serviceKey", value: accessKey)]
+            var items: [URLQueryItem] = []
             params.forEach() { item in
                 items.append(URLQueryItem(name: item.key, value: item.value))
             }
             components.queryItems = items
+            if let query = components.percentEncodedQuery  {
+                components.percentEncodedQuery = query + "&serviceKey=" + accessKey
+            }
             
             if let url = components.url {
                 var request = URLRequest(url: url)

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -80,7 +80,7 @@ class HomeViewController: UIViewController {
 
     private func bindingFavoriteList() {
         self.cancellable = self.viewModel?.$homeFavoriteList
-            .receive(on: HomeUseCase.thread)
+            .throttle(for: .seconds(1), scheduler: HomeUseCase.thread, latest: true)
             .sink(receiveValue: { response in
                 DispatchQueue.main.async {
                     self.homeView.reload()

--- a/BBus/BBus/Home/Model/HomeModel.swift
+++ b/BBus/BBus/Home/Model/HomeModel.swift
@@ -48,6 +48,14 @@ struct HomeFavoriteList {
 
         return IndexPath(row: row, section: section)
     }
+
+    mutating func descendAllTime() {
+        self.favorites = self.favorites.map({
+            var favorite = $0
+            favorite.descendTime()
+            return favorite
+        })
+    }
 }
 
 struct HomeFavorite: Equatable {
@@ -83,11 +91,18 @@ struct HomeFavorite: Equatable {
         self.buses[row].1 = homeArrivalInfo
     }
 
+    mutating func descendTime() {
+        self.buses = self.buses.map({
+            guard var arriveInfo = $0.1 else { return ($0.0, nil) }
+            arriveInfo.descended()
+            return ($0.0, arriveInfo)
+        })
+    }
 }
 
 struct HomeArriveInfo {
-    let firstTime: BusRemainTime
-    let secondTime: BusRemainTime
+    var firstTime: BusRemainTime
+    var secondTime: BusRemainTime
     let firstRemainStation: String?
     let secondRemainStation: String?
     let firstBusCongestion: BusCongestion?
@@ -102,5 +117,14 @@ struct HomeArriveInfo {
         self.secondRemainStation = secondSeperatedTuple.position
         self.firstBusCongestion = BusCongestion(rawValue: arrInfoByRouteDTO.firstBusCongestion)
         self.secondBusCongestion = BusCongestion(rawValue: arrInfoByRouteDTO.secondBusCongestion)
+    }
+
+    mutating func descended() {
+        if let first = self.firstTime.seconds {
+            self.firstTime.seconds = first - 1
+        }
+        if let second = self.secondTime.seconds {
+            self.secondTime.seconds = second - 1
+        }
     }
 }

--- a/BBus/BBus/Home/Model/HomeModel.swift
+++ b/BBus/BBus/Home/Model/HomeModel.swift
@@ -94,7 +94,7 @@ struct HomeFavorite: Equatable {
     mutating func descendTime() {
         self.buses = self.buses.map({
             guard var arriveInfo = $0.1 else { return ($0.0, nil) }
-            arriveInfo.descended()
+            arriveInfo.descend()
             return ($0.0, arriveInfo)
         })
     }
@@ -119,12 +119,8 @@ struct HomeArriveInfo {
         self.secondBusCongestion = BusCongestion(rawValue: arrInfoByRouteDTO.secondBusCongestion)
     }
 
-    mutating func descended() {
-        if let first = self.firstTime.seconds {
-            self.firstTime.seconds = first - 1
-        }
-        if let second = self.secondTime.seconds {
-            self.secondTime.seconds = second - 1
-        }
+    mutating func descend() {
+        self.firstTime.descend()
+        self.secondTime.descend()
     }
 }

--- a/BBus/BBus/Home/ViewModel/HomeViewModel.swift
+++ b/BBus/BBus/Home/ViewModel/HomeViewModel.swift
@@ -17,6 +17,14 @@ class HomeViewModel {
     init(useCase: HomeUseCase) {
         self.useCase = useCase
         self.bindFavoriteData()
+        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "haha"), object: nil, queue: .main) { _ in
+
+            self.descendTime()
+        }
+    }
+
+    private func descendTime() {
+        self.homeFavoriteList?.descendAllTime()
     }
 
     private func bindFavoriteData() {

--- a/BBus/BBus/Home/ViewModel/HomeViewModel.swift
+++ b/BBus/BBus/Home/ViewModel/HomeViewModel.swift
@@ -17,8 +17,11 @@ class HomeViewModel {
     init(useCase: HomeUseCase) {
         self.useCase = useCase
         self.bindFavoriteData()
-        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "haha"), object: nil, queue: .main) { _ in
+        self.configureObserver()
+    }
 
+    private func configureObserver() {
+        NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
             self.descendTime()
         }
     }

--- a/BBus/BBus/SceneDelegate.swift
+++ b/BBus/BBus/SceneDelegate.swift
@@ -24,7 +24,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
               let movingStatusWindow = self.movingStatusWindow else { return }
         self.movingStatusWindow?.frame.size = CGSize(width: movingStatusWindow.frame.width, height: movingStatusWindow.frame.height + MovingStatusView.bottomIndicatorHeight)
         self.appCoordinator = AppCoordinator(navigationWindow: navigationWindow, movingStatusWindow: movingStatusWindow)
-        
+
+        let timer = Timer.init(timeInterval: 1, repeats: true) { _ in
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "haha"), object: nil)
+        }
+        RunLoop.current.add(timer, forMode: .common)
+//        Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+//            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "haha"), object: nil)
+//        }
         appCoordinator?.start()
     }
 

--- a/BBus/BBus/SceneDelegate.swift
+++ b/BBus/BBus/SceneDelegate.swift
@@ -24,15 +24,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
               let movingStatusWindow = self.movingStatusWindow else { return }
         self.movingStatusWindow?.frame.size = CGSize(width: movingStatusWindow.frame.width, height: movingStatusWindow.frame.height + MovingStatusView.bottomIndicatorHeight)
         self.appCoordinator = AppCoordinator(navigationWindow: navigationWindow, movingStatusWindow: movingStatusWindow)
+        appCoordinator?.start()
 
+        self.fireMainTimer()
+    }
+
+    func fireMainTimer() {
         let timer = Timer.init(timeInterval: 1, repeats: true) { _ in
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "haha"), object: nil)
+            NotificationCenter.default.post(name: .oneSecondPassed, object: nil)
         }
         RunLoop.current.add(timer, forMode: .common)
-//        Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-//            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "haha"), object: nil)
-//        }
-        appCoordinator?.start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -62,7 +63,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
 
 }
 

--- a/BBus/BBus/Station/Model/BusRemainTime.swift
+++ b/BBus/BBus/Station/Model/BusRemainTime.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct BusRemainTime {
-    let seconds: Int?
+    var seconds: Int?
     let message: String?
-    
+
     init(arriveRemainTime: String) {
         let times = arriveRemainTime.components(separatedBy: ["분", "초"])
         switch times.count {
@@ -35,7 +35,7 @@ struct BusRemainTime {
         if let time = self.seconds {
             let minutes = time / 60
             let seconds = time % 60
-            return "\(minutes)분 \(seconds)초"
+            return minutes >= 1 ? "\(minutes)분 \(seconds)초" : "\(max(seconds, 0))초"
         }
         else {
             return self.checkInfo() ? self.message : nil

--- a/BBus/BBus/Station/Model/BusRemainTime.swift
+++ b/BBus/BBus/Station/Model/BusRemainTime.swift
@@ -53,4 +53,10 @@ struct BusRemainTime {
         let noInfoMessages = ["운행종료", "출발대기"]
         return !noInfoMessages.contains(message)
     }
+
+    mutating func descend() {
+        if let second = self.seconds {
+            self.seconds = second - 1
+        }
+    }
 }

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -109,44 +109,54 @@ class StationViewController: UIViewController {
     
     private func binding() {
         self.$stationBusInfoHeight
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .sink() { [weak self] height in
-                self?.collectionHeightConstraint?.isActive = false
-                self?.collectionHeightConstraint = self?.stationView.configureTableViewHeight(height: height)
+                DispatchQueue.main.async {
+                    self?.collectionHeightConstraint?.isActive = false
+                    self?.collectionHeightConstraint = self?.stationView.configureTableViewHeight(height: height)
+                }
             }.store(in: &self.cancellables)
         
         self.viewModel?.usecase.$stationInfo
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .sink(receiveValue: { [weak self] station in
-                guard let station = station else { return }
-                self?.stationView.configureHeaderView(stationId: station.arsID, stationName: station.stationName)
+                DispatchQueue.main.async {
+                    guard let station = station else { return }
+                    self?.stationView.configureHeaderView(stationId: station.arsID, stationName: station.stationName)
+                }
             })
             .store(in: &self.cancellables)
         
         self.viewModel?.$nextStation
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .sink(receiveValue: { [weak self] nextStation in
-                guard let nextStation = nextStation else { return }
-                self?.stationView.configureNextStation(direction: nextStation)
+                DispatchQueue.main.async {
+                    guard let nextStation = nextStation else { return }
+                    self?.stationView.configureNextStation(direction: nextStation)
+                }
             })
             .store(in: &self.cancellables)
         
         self.viewModel?.$busKeys
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .sink(receiveValue: { [weak self] _ in
-                self?.stationView.reload()
+                DispatchQueue.main.async {
+                    self?.stationView.reload()
+                }
             })
             .store(in: &self.cancellables)
         
         self.viewModel?.$favoriteItems
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .sink(receiveValue: { [weak self] _ in
-                self?.stationView.reload()
+                DispatchQueue.main.async {
+                    self?.stationView.reload()
+                }
             })
             .store(in: &self.cancellables)
 
         self.viewModel?.$infoBuses
-            .receive(on: DispatchQueue.main)
+            .receive(on: StationUsecase.queue)
             .throttle(for: .seconds(1), scheduler: DispatchQueue.global(), latest: true)
             .sink(receiveValue: { [weak self] _ in
                 DispatchQueue.main.async {

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -147,8 +147,11 @@ class StationViewController: UIViewController {
 
         self.viewModel?.$infoBuses
             .receive(on: DispatchQueue.main)
+            .throttle(for: .seconds(1), scheduler: DispatchQueue.global(), latest: true)
             .sink(receiveValue: { [weak self] _ in
-                self?.stationView.reload()
+                DispatchQueue.main.async {
+                    self?.stationView.reload()
+                }
             })
             .store(in: &self.cancellables)
     }

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -144,6 +144,13 @@ class StationViewController: UIViewController {
                 self?.stationView.reload()
             })
             .store(in: &self.cancellables)
+
+        self.viewModel?.$infoBuses
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                self?.stationView.reload()
+            })
+            .store(in: &self.cancellables)
     }
 
     private func configureColor() {


### PR DESCRIPTION
## 작업 내용
- [x] 1초 간격으로 작동하는 타이머 생성
- [x] 타이머가 필요한 모든 화면에서 타이머를 사용할 수 있도록 구현
- [x] 타이머가 필요한 모든 화면에서 타이머에 따라 1초 간격으로 남은 시간 레이블 변경시키기 

## 시연 방법
|홈 화면|알람 설정 화면|정거장 화면|
|:---:|:---:|:---:|
|![](https://i.imgur.com/xIQkCeX.gif)|![](https://i.imgur.com/Ym98Phj.gif)|![](https://i.imgur.com/ezFeDvI.gif)|


## 기타 (고민과 해결, 리뷰 포인트 등)
* SceneDelegate에서 Timer를 fire해줌.
    * 1초 타이머를 작동시켜, 타이머가 필요한 각 화면에서 그 액션을 받아서 사용하기로 결정
    * 만약 각 화면에서 타이머를 독립적으로 작동시킨다면, 화면이 계속 push 됨에 따라 타이머가 오작동하거나 메모리상에서 해제되지 않은 채 남을 수 있다.
    * 기존에는 아래와 같이 Timer를 작동시켰음.
        ```swift
        Timer.init(timeInterval: 1, repeats: true) {
            NotificationCenter.default.post(name: .oneSecondPassed, object: nil)
        }
        ```
    
    * 서치 결과 타이머는 main run loop에서 돌리는 것이 가장 안정하다고 함. (run loop 관련 지식은 이슈 #123 참고)
    * 하지만 main run loop는 뷰 관련 입력 이벤트가 처리되는 런루프로 타이머와 뷰 이벤트를 모두 처리하기에 버거울 수 있다.
    * run loop mode를 common으로 하면 main에서 이루어지는 view 관련 이벤트의 영향을 덜 받도록 할 수 있음.
    * default 모드에서는 스크롤 시 타이머가 멈추는 증상이 있었지만 common으로 변경 후에는 해결됨.
        ```swift
        let timer = Timer.init(timeInterval: 1, repeats: true) { _ in
            NotificationCenter.default.post(name: .oneSecondPassed, object: nil)
        }
        RunLoop.current.add(timer, forMode: .common)
        ```

* combine 구조를 유지하기 위해 Publisher로 스트림을 연결시켜줄까 생각했지만, Publisher를 각 ViewModel에 주입시켜줘야 하는 등 코드를 개선하는 비용이 너무 커서 사양 
* 간단하게 구현할 수 있는 NotificationCenter를 통해 구현하였음.
* 1초 타이머가 필요한 ViewModel에서 NotificationCenter로 .oneSecondPassed에 addObserver를 시킴
* post되었으면 시간 변화(감소)가 필요한 모델에 변경을 일으켜, 궁극적으로 collectionView의 `reload()` 를 유발시킴으로써 변화에 대응
    * 이게 가능한 이유는 ViewController에서 해당 모델에 bind 되어있기 때문이다.