### PR TITLE
fix: #167 승차 알람 섹션만 매 초마다 갱신하는 방식으로 변경

### DIFF
--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -103,7 +103,7 @@ class AlarmSettingViewController: UIViewController {
             .throttle(for: .seconds(1), scheduler: AlarmSettingUseCase.queue, latest: true)
             .sink(receiveValue: { [weak self] data in
                 DispatchQueue.main.async {
-                    self?.alarmSettingView.reload()
+                    self?.alarmSettingView.reloadGetOnSection()
                 }
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
+++ b/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
@@ -50,7 +50,7 @@ class AlarmSettingView: UIView {
         self.alarmTableView.dataSource = delegate
     }
     
-    func reload() {
-        self.alarmTableView.reloadData()
+    func reloadGetOnSection() {
+        self.alarmTableView.reloadSections(IndexSet(integer: .zero), with: .none)
     }
 }


### PR DESCRIPTION
## 작업 내용
#167  참고

- [x] 0번째 섹션만 새로고침 하도록 수정

## 시연 방법
* 알람설정 화면에서 하차알람을 설정한다.

https://user-images.githubusercontent.com/72058473/142147328-f390d2fa-6668-46fc-a7fe-e9902820f2d0.mp4

## 기타 (고민과 해결, 리뷰 포인트 등)
* Section만 업데이트 해주는 방식으로 변경