### PR TITLE
[새로고침 버튼] 모든 새로고침 버튼에 throttle 할 수 있게 커스텀하여 만들어준다. 

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		049375BD273C2E120061ACDA /* ArrInfoByRouteDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049375BC273C2E120061ACDA /* ArrInfoByRouteDTO.swift */; };
 		049375BF273C326A0061ACDA /* StationsByPosDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049375BE273C326A0061ACDA /* StationsByPosDTO.swift */; };
 		049375C3273C36880061ACDA /* BBusXMLDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049375C2273C36880061ACDA /* BBusXMLDTO.swift */; };
+		049B9D002744D2AA004DE66E /* ThrottleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049B9CFF2744D2AA004DE66E /* ThrottleButton.swift */; };
 		04AC7D112733AF090095CD4E /* BusRouteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AC7D102733AF090095CD4E /* BusRouteTableViewCell.swift */; };
 		04AC7D132733B0940095CD4E /* GetOffTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AC7D122733B0940095CD4E /* GetOffTableViewCell.swift */; };
 		04AC7D1B2733E7270095CD4E /* AlarmSettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AC7D1A2733E7270095CD4E /* AlarmSettingButton.swift */; };
@@ -142,6 +143,7 @@
 		049375BC273C2E120061ACDA /* ArrInfoByRouteDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrInfoByRouteDTO.swift; sourceTree = "<group>"; };
 		049375BE273C326A0061ACDA /* StationsByPosDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsByPosDTO.swift; sourceTree = "<group>"; };
 		049375C2273C36880061ACDA /* BBusXMLDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BBusXMLDTO.swift; sourceTree = "<group>"; };
+		049B9CFF2744D2AA004DE66E /* ThrottleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottleButton.swift; sourceTree = "<group>"; };
 		04AC7D102733AF090095CD4E /* BusRouteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteTableViewCell.swift; sourceTree = "<group>"; };
 		04AC7D122733B0940095CD4E /* GetOffTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOffTableViewCell.swift; sourceTree = "<group>"; };
 		04AC7D1A2733E7270095CD4E /* AlarmSettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingButton.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				873D6394273039C400E79069 /* Coordinator */,
 				047C30F8273A044C0075EA14 /* Constant */,
 				041A5A0F273D2E0400490075 /* Extension */,
+				049B9CFE2744D27F004DE66E /* View */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -307,6 +310,14 @@
 				4A06AEC7274159D10027222D /* FavoriteItemDTO.swift */,
 			);
 			path = DTO;
+			sourceTree = "<group>";
+		};
+		049B9CFE2744D27F004DE66E /* View */ = {
+			isa = PBXGroup;
+			children = (
+				049B9CFF2744D2AA004DE66E /* ThrottleButton.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		4ACA51D7272FCC4E00EC0531 /* Home */ = {
@@ -879,6 +890,7 @@
 				4A1A22E12732CE7900476861 /* SearchResultCollectionViewCell.swift in Sources */,
 				87EB52AE2733A6C6000D5492 /* GetOnStatusCell.swift in Sources */,
 				4A06AEE92743DAB20027222D /* NotificationNameExtension.swift in Sources */,
+				049B9D002744D2AA004DE66E /* ThrottleButton.swift in Sources */,
 				4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */,
 				4A7BBFED2737885F0029915F /* StationHeaderView.swift in Sources */,
 				049375B5273BB98E0061ACDA /* StationByRouteListDTO.swift in Sources */,

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -21,6 +21,9 @@ class AlarmSettingViewController: UIViewController {
         button.layer.cornerRadius = radius
         button.tintColor = BBusColor.white
         button.backgroundColor = BBusColor.darkGray
+        button.addAction(UIAction(handler: { _ in
+            self.viewModel?.refresh()
+        }), for: .touchUpInside)
         return button
     }()
     private let viewModel: AlarmSettingViewModel?

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -13,17 +13,17 @@ class AlarmSettingViewController: UIViewController {
     weak var coordinator: AlarmSettingCoordinator?
     private lazy var alarmSettingView = AlarmSettingView()
     private lazy var customNavigationBar = CustomNavigationBar()
-    private lazy var refreshButton: UIButton = {
+    private lazy var refreshButton: ThrottleButton = {
         let radius: CGFloat = 25
 
-        let button = UIButton()
+        let button = ThrottleButton()
         button.setImage(BBusImage.refresh, for: .normal)
         button.layer.cornerRadius = radius
         button.tintColor = BBusColor.white
         button.backgroundColor = BBusColor.darkGray
-        button.addAction(UIAction(handler: { _ in
+        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) {
             self.viewModel?.refresh()
-        }), for: .touchUpInside)
+        }
         return button
     }()
     private let viewModel: AlarmSettingViewModel?

--- a/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -33,6 +33,9 @@ class AlarmSettingViewModel {
         NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
             self.descendTime()
         }
+        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .main) { _ in
+            self.refresh()
+        }
     }
     
     private func descendTime() {

--- a/BBus/BBus/Global/Extension/NotificationNameExtension.swift
+++ b/BBus/BBus/Global/Extension/NotificationNameExtension.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let oneSecondPassed = Self.init(rawValue: "oneSecondPassed")
+    static let thirtySecondPassed = Self.init(rawValue: "thirtySecondPassed")
 }

--- a/BBus/BBus/Global/View/ThrottleButton.swift
+++ b/BBus/BBus/Global/View/ThrottleButton.swift
@@ -1,0 +1,41 @@
+//
+//  ThrottleButton.swift
+//  BBus
+//
+//  Created by 최수정 on 2021/11/17.
+//
+
+import UIKit
+
+class ThrottleButton: UIButton {
+
+    private var workItem: DispatchWorkItem?
+    private var delay: Double = 0
+    private var callback: (() -> Void)?
+    
+    func addTouchUpEventWithThrottle(delay: Double, callback: @escaping (() -> Void)) {
+        self.delay = delay
+        self.callback = callback
+        
+        self.addTarget(self, action: #selector(self.touchUpInside(_:)), for: .touchUpInside)
+    }
+    
+    @objc private func touchUpInside(_ sender: UIButton) {
+        if self.workItem == nil {
+            self.callback?()
+            
+            let workItem = DispatchWorkItem(block: { [weak self] in
+                self?.workItem?.cancel()
+                self?.workItem = nil
+            })
+            self.workItem = workItem
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.delay, execute: workItem)
+        }
+    }
+    
+    deinit {
+        self.removeTarget(self, action: #selector(self.touchUpInside(_:)), for: .touchUpInside)
+    }
+
+}

--- a/BBus/BBus/Global/View/ThrottleButton.swift
+++ b/BBus/BBus/Global/View/ThrottleButton.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class ThrottleButton: UIButton {
+    
+    static let refreshInterval: Double = 3
 
     private var workItem: DispatchWorkItem?
     private var delay: Double = 0
@@ -30,7 +32,7 @@ class ThrottleButton: UIButton {
             })
             self.workItem = workItem
             
-            DispatchQueue.main.asyncAfter(deadline: .now() + self.delay, execute: workItem)
+            DispatchQueue.global().asyncAfter(deadline: .now() + self.delay, execute: workItem)
         }
     }
     

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -17,14 +17,14 @@ class HomeViewController: UIViewController {
     private let viewModel: HomeViewModel?
 
     private lazy var homeView = HomeView()
-    lazy var refreshButton: UIButton = {
-        let button = UIButton()
+    lazy var refreshButton: ThrottleButton = {
+        let button = ThrottleButton()
         button.setImage(BBusImage.refresh, for: .normal)
         button.layer.cornerRadius = self.refreshButtonWidth / 2
         button.tintColor = BBusColor.white
-        button.addAction(UIAction(handler: { _ in
+        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) {
             self.viewModel?.reloadFavoriteData()
-        }), for: .touchUpInside)
+        }
         return button
     }()
 

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -9,11 +9,25 @@ import UIKit
 import Combine
 
 class HomeViewController: UIViewController {
-    
+
+    private var lastContentOffset: CGFloat = 0
+    private let refreshButtonWidth: CGFloat = 50
+
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
+
     private lazy var homeView = HomeView()
-    private var lastContentOffset: CGFloat = 0
+    lazy var refreshButton: UIButton = {
+        let button = UIButton()
+        button.setImage(BBusImage.refresh, for: .normal)
+        button.layer.cornerRadius = self.refreshButtonWidth / 2
+        button.tintColor = BBusColor.white
+        button.addAction(UIAction(handler: { _ in
+            self.viewModel?.reloadFavoriteData()
+        }), for: .touchUpInside)
+        return button
+    }()
+
     private var cancellable: AnyCancellable?
 
     init(viewModel: HomeViewModel) {
@@ -68,6 +82,18 @@ class HomeViewController: UIViewController {
             self.homeView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
             self.homeView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
         ])
+
+        self.view.addSubview(self.refreshButton)
+        self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
+        self.refreshButton.backgroundColor = BBusColor.darkGray
+        let refreshTrailingBottomInterval: CGFloat = -16
+        NSLayoutConstraint.activate([
+            self.refreshButton.widthAnchor.constraint(equalToConstant: self.refreshButtonWidth),
+            self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
+            self.refreshButton.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: refreshTrailingBottomInterval),
+            self.refreshButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: refreshTrailingBottomInterval)
+        ])
+
     }
     
     private func configureColor() {

--- a/BBus/BBus/Home/View/HomeView.swift
+++ b/BBus/BBus/Home/View/HomeView.swift
@@ -9,8 +9,7 @@ import UIKit
 
 class HomeView: UIView {
 
-    private let refreshButtonWidth: CGFloat = 50
-    
+
     private lazy var favoriteCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: CGRect(), collectionViewLayout: self.collectionViewLayout())
         collectionView.register(FavoriteCollectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoriteCollectionHeaderView.identifier)
@@ -24,13 +23,6 @@ class HomeView: UIView {
         let view = HomeNavigationView()
         view.backgroundColor = BBusColor.white
         return view
-    }()
-    lazy var refreshButton: UIButton = {
-        let button = UIButton()
-        button.setImage(BBusImage.refresh, for: .normal)
-        button.layer.cornerRadius = self.refreshButtonWidth / 2
-        button.tintColor = BBusColor.white
-        return button
     }()
 
     convenience init() {
@@ -50,17 +42,6 @@ class HomeView: UIView {
             self.favoriteCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
 
-        self.addSubview(self.refreshButton)
-        self.refreshButton.translatesAutoresizingMaskIntoConstraints = false
-        self.refreshButton.backgroundColor = BBusColor.darkGray
-        let refreshTrailingBottomInterval: CGFloat = -16
-        NSLayoutConstraint.activate([
-            self.refreshButton.widthAnchor.constraint(equalToConstant: self.refreshButtonWidth),
-            self.refreshButton.heightAnchor.constraint(equalTo: self.refreshButton.widthAnchor),
-            self.refreshButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: refreshTrailingBottomInterval),
-            self.refreshButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: refreshTrailingBottomInterval)
-        ])
-        
         self.addSubview(self.navigationView)
         self.navigationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/BBus/BBus/Home/ViewModel/HomeViewModel.swift
+++ b/BBus/BBus/Home/ViewModel/HomeViewModel.swift
@@ -24,6 +24,9 @@ class HomeViewModel {
         NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
             self.descendTime()
         }
+        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .main) { _ in
+            self.reloadFavoriteData()
+        }
     }
 
     private func descendTime() {

--- a/BBus/BBus/SceneDelegate.swift
+++ b/BBus/BBus/SceneDelegate.swift
@@ -26,12 +26,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.appCoordinator = AppCoordinator(navigationWindow: navigationWindow, movingStatusWindow: movingStatusWindow)
         appCoordinator?.start()
 
-        self.fireMainTimer()
+        self.fireOneSecondTimer()
+        self.fire30SecondsTimer()
     }
 
-    func fireMainTimer() {
+    func fireOneSecondTimer() {
         let timer = Timer.init(timeInterval: 1, repeats: true) { _ in
             NotificationCenter.default.post(name: .oneSecondPassed, object: nil)
+        }
+        RunLoop.current.add(timer, forMode: .common)
+    }
+
+    func fire30SecondsTimer() {
+        let timer = Timer.init(timeInterval: 30, repeats: true) { _ in
+            NotificationCenter.default.post(name: .thirtySecondPassed, object: nil)
         }
         RunLoop.current.add(timer, forMode: .common)
     }

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -32,18 +32,17 @@ class StationViewController: UIViewController {
         view.backgroundColor = BBusColor.white
         return view
     }()
-    private lazy var refreshButton: UIButton = {
+    private lazy var refreshButton: ThrottleButton = {
         let radius: CGFloat = 25
 
-        let button = UIButton()
+        let button = ThrottleButton()
         button.setImage(BBusImage.refresh, for: .normal)
         button.layer.cornerRadius = radius
         button.tintColor = UIColor.white
         button.backgroundColor = UIColor.darkGray
-        
-        button.addAction(UIAction(handler: { _ in
+        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) {
             self.viewModel?.refresh()
-        }), for: .touchUpInside)
+        }
         return button
     }()
     private var collectionHeightConstraint: NSLayoutConstraint?

--- a/BBus/BBus/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Station/ViewModel/StationViewModel.swift
@@ -37,6 +37,9 @@ class StationViewModel {
         NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
             self.descendTime()
         }
+        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .main) { _ in
+            self.refresh()
+        }
     }
     
     func refresh() {


### PR DESCRIPTION
## 작업 내용
- [x] throttle 할 수 있는 Custom Button 생성

## 시연 방법
새로고침 버튼을 연타해도 3초에 한 번 씩만 refresh()가 호출됨.
![Simulator Screen Recording - iPhone 12 - 2021-11-17 at 15 38 09](https://user-images.githubusercontent.com/70833900/142147448-07078fc7-9d6d-40f7-bc61-a96fa9ba0944.gif)


## 기타 (고민과 해결, 리뷰 포인트 등)
* 새로고침을 연타하는경우 API 요청이 너무 많아져서 토큰이 소진될 우려가 있다.
* 따라서 일정 시간동안 모든 요청을 하나로 바꿔주는 throttle 기술을 적용한 버튼이 필요


