### PR TITLE
[승하차 알람] 10-3. 정거장 셀의 알람 버튼을 터치하면 실시간 이동 현황 화면으로 전환되어야 한다. 

### DIFF
--- a/BBus/BBus/AlarmSetting/AlarmSettingCoordinator.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingCoordinator.swift
@@ -33,8 +33,8 @@ class AlarmSettingCoordinator: Coordinator {
         self.coordinatorDidFinish()
     }
     
-    func openMovingStatus() {
-        self.movingStatusDelegate?.open()
+    func openMovingStatus(busRouteId: Int, fromArsId: String, toArsId: String) {
+        self.movingStatusDelegate?.open(busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)
     }
     
     func closeMovingStatus() {

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -230,9 +230,14 @@ extension AlarmSettingViewController: BackButtonDelegate {
 
 // MARK: - Delegate: GetOffAlarmButton
 extension AlarmSettingViewController: GetOffAlarmButtonDelegate {
-    func shouldGoToMovingStatusScene() {
+    func shouldGoToMovingStatusScene(from cell: UITableViewCell) {
+        guard let busRouteId = self.viewModel?.busRouteId,
+              let indexPath = self.alarmSettingView.indexPath(for: cell),
+              let startStationArsId = self.viewModel?.busStationInfos.first?.arsId,
+              let endStationArsId = self.viewModel?.busStationInfos[indexPath.item].arsId else { return }
+        
         UIView.animate(withDuration: 0.3) {
-            self.coordinator?.openMovingStatus()
+            self.coordinator?.openMovingStatus(busRouteId: busRouteId, fromArsId: startStationArsId, toArsId: endStationArsId)
         }
     }
 }

--- a/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
+++ b/BBus/BBus/AlarmSetting/View/AlarmSettingView.swift
@@ -53,4 +53,8 @@ class AlarmSettingView: UIView {
     func reload() {
         self.alarmTableView.reloadData()
     }
+    
+    func indexPath(for cell: UITableViewCell) -> IndexPath? {
+        return self.alarmTableView.indexPath(for: cell)
+    }
 }

--- a/BBus/BBus/AlarmSetting/View/GetOffTableViewCell.swift
+++ b/BBus/BBus/AlarmSetting/View/GetOffTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol GetOffAlarmButtonDelegate {
-    func shouldGoToMovingStatusScene()
+    func shouldGoToMovingStatusScene(from cell: UITableViewCell)
 }
 
 class GetOffTableViewCell: BusStationTableViewCell {
@@ -30,7 +30,7 @@ class GetOffTableViewCell: BusStationTableViewCell {
         didSet {
             self.alarmButton.addAction(UIAction(handler: { _ in
                 self.alarmButton.isSelected.toggle()
-                self.alarmButtonDelegate?.shouldGoToMovingStatusScene()
+                self.alarmButtonDelegate?.shouldGoToMovingStatusScene(from: self)
             }), for: .touchUpInside)
         }
     }

--- a/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -14,7 +14,7 @@ class AlarmSettingViewModel {
     
     let useCase: AlarmSettingUseCase
     private let stationId: Int
-    private let busRouteId: Int
+    let busRouteId: Int
     private let stationOrd: Int
     private let arsId: String
     @Published private(set) var busArriveInfos: [AlarmSettingBusArriveInfo]

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -53,11 +53,10 @@ extension AppCoordinator: MovingStatusFoldUnfoldDelegate {
 }
 
 extension AppCoordinator: MovingStatusOpenCloseDelegate {
-    func open() {
-        //TODO: busRouteId(버스정보), fromArsId(승차점), toArsId(하차점) 파라미터가 필요
+    func open(busRouteId: Int, fromArsId: String, toArsId: String) {
 
         let usecase = MovingStatusUsecase(usecases: BBusAPIUsecases(on: MovingStatusUsecase.queue))
-        let viewModel = MovingStatusViewModel(usecase: usecase, busRouteId: 100100048, fromArsId: "07168", toArsId: "06011")
+        let viewModel = MovingStatusViewModel(usecase: usecase, busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)
         let viewController = MovingStatusViewController(viewModel: viewModel)
         viewController.coordinator = self
         self.movingStatusPresenter = viewController

--- a/BBus/BBus/MovingStatus/MovingStatusFoldUnfoldDelegate.swift
+++ b/BBus/BBus/MovingStatus/MovingStatusFoldUnfoldDelegate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MovingStatusOpenCloseDelegate: AnyObject {
-    func open()
+    func open(busRouteId: Int, fromArsId: String, toArsId: String)
     func close()
 }
 


### PR DESCRIPTION
## 작업 내용
- [x]  정거장 셀의 알람 버튼을 터치하면 실시간 이동 현황 화면으로 전환되어야 한다.

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
