### PR TITLE
[승하차 알람] 11-4. 1정거장 전부터는 "이번에 내리세요" 라는 메세지가 말풍선 아이콘에 표시되어야 한다.

### DIFF
--- a/BBus/BBus/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/MovingStatus/MovingStatusViewController.swift
@@ -92,9 +92,7 @@ final class MovingStatusViewController: UIViewController {
                 DispatchQueue.main.async {
                     self?.movingStatusView.configureBusName(to: busInfo.busName)
                     self?.configureBusColor(type: busInfo.type)
-
-                    let testBus = BoardedBus(location: 2.0, remainStation: 5)
-                    self?.configureBusTag(bus: testBus)
+                    self?.configureBusTag(bus: nil)
                 }
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/MovingStatus/MovingStatusViewController.swift
@@ -104,6 +104,10 @@ final class MovingStatusViewController: UIViewController {
             .sink(receiveValue: { [weak self] remainingTime in
                 DispatchQueue.main.async {
                     self?.movingStatusView.configureHeaderInfo(remainStation: self?.viewModel?.remainingStation, remainTime: remainingTime)
+                    // test 용 bus 생성
+//                    guard let count = self?.viewModel?.stationInfos.count else { return }
+//                    let testBus = BoardedBus(location: 4.5, remainStation: count-5)
+//                    self?.configureBusTag(bus: testBus)
                 }
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/MovingStatus/View/MovingStatusBusTagView.swift
+++ b/BBus/BBus/MovingStatus/View/MovingStatusBusTagView.swift
@@ -16,7 +16,7 @@ class MovingStatusBusTagView: UIView {
     }()
     private lazy var speechBubbleImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = BBusImage.speechBubble
+        imageView.image = BBusImage.speechBubble?.withRenderingMode(.alwaysTemplate)
         return imageView
     }()
     private lazy var movingStatusLabel: UILabel = {

--- a/BBus/BBus/MovingStatus/View/MovingStatusBusTagView.swift
+++ b/BBus/BBus/MovingStatus/View/MovingStatusBusTagView.swift
@@ -89,7 +89,7 @@ class MovingStatusBusTagView: UIView {
         self.speechBubbleImageView.tintColor = color
         self.booduckBusImageView.image = busIcon
         if let remainStation = remainStation {
-            self.movingStatusLabel.text = "\(remainStation)정거장 남음"
+            self.movingStatusLabel.text = remainStation > 1 ? "\(remainStation)정거장 남음" : "이번에 내리세요!"
         } else {
             self.movingStatusLabel.text = "현위치 탐색중"
         }

--- a/BBus/BBus/MovingStatus/View/MovingStatusView.swift
+++ b/BBus/BBus/MovingStatus/View/MovingStatusView.swift
@@ -324,12 +324,13 @@ class MovingStatusView: UIView {
         let currentInfo: String
 
         if let remainStation = remainStation {
-            currentInfo = "\(remainStation)정거장 남음"
+            currentInfo = remainStation > 1 ? "\(remainStation)정거장 남음" : "이번에 내리세요!"
         } else {
             currentInfo = "현위치 탐색중"
         }
-        if let remainTime = remainTime {
-            headerInfoResult = "\(currentInfo), \(remainTime)분 소요예정"
+        if let remainTime = remainTime,
+           let remainStation = remainStation {
+            headerInfoResult = remainStation > 1 ? "\(currentInfo), \(remainTime)분 소요예정" : currentInfo
         } else {
             headerInfoResult = currentInfo
         }


### PR DESCRIPTION
## 작업 내용
- [x] 사용자의 현재 정거장의 위치와 도착 정거장간의 남은 정거장 수를 계산해야 한다.
- [x] 남은 정거장 수가 1정거장일 경우 "이번에 내리세요" 라는 내용을 표시한다.

## 시연 방법
| Case 1 | Case 2 |
| -------- | -------- |
| <img src="https://i.imgur.com/l3z0OsP.jpg"> | <img src="https://i.imgur.com/6ZCTIhS.jpg"> |
| 1정거장 로직 1 | 1정거장 로직 2 |
| <img src="https://i.imgur.com/y5OQ0In.jpg"> | <img src="https://i.imgur.com/lfwF3qy.jpg"> |

- viewModel 의 남은 정거장 수에 따라 말풍선에 표시가 된다.
- `self.viewModel?.$remainingStation` 값을 바인딩 하고 있어 `self?.movingStatusView.configureHeaderInfo(remainStation: currentStation, remainTime: self?.viewModel?.remainingTime)` 가 실행되는 구조
- 현재로선  `self.viewModel?.$remainingStation` 값이 바뀔 수 없기에 임의로 값을 대입하여 테스트

## 기타 (고민과 해결, 리뷰 포인트 등)
