### PR TITLE
[승하차 알람] 9-7. 1번째 전 정거장에 버스가 위치할 경우 알람 등록이 되지 않으며 "버스가 곧 도착합니다"라는 메시지를 띄운다.

### DIFF
--- a/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
+++ b/BBus/BBus/AlarmSetting/View/GetOnStatusCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol GetOnAlarmButtonDelegate {
-    func toggleGetOnAlarmSetting()
+    func toggleGetOnAlarmSetting(for cell: UITableViewCell, cancel: Bool) -> Bool?
 }
 
 class GetOnStatusCell: UITableViewCell {
@@ -133,9 +133,12 @@ class GetOnStatusCell: UITableViewCell {
 
     private var alarmButtonDelegate: GetOnAlarmButtonDelegate? {
         didSet {
-            self.alarmButton.addAction(UIAction(handler: { _ in
-                self.alarmButton.isSelected.toggle()
-                self.alarmButtonDelegate?.toggleGetOnAlarmSetting()
+            self.alarmButton.addAction(UIAction(handler: { [weak self] _ in
+                guard let self = self else { return }
+                let result = self.alarmButtonDelegate?.toggleGetOnAlarmSetting(for: self, cancel: self.alarmButton.isSelected)
+                if result == true {
+                    self.alarmButton.isSelected.toggle()
+                }
             }), for: .touchUpInside)
         }
     }

--- a/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -20,6 +20,7 @@ class AlarmSettingViewModel {
     let routeType: RouteType?
     @Published private(set) var busArriveInfos: [AlarmSettingBusArriveInfo]
     @Published private(set) var busStationInfos: [AlarmSettingBusStationInfo]
+    @Published private(set) var errorMessage: String?
     private var cancellables: Set<AnyCancellable>
     
     init(useCase: AlarmSettingUseCase, stationId: Int, busRouteId: Int, stationOrd: Int, arsId: String, routeType: RouteType?) {
@@ -32,6 +33,7 @@ class AlarmSettingViewModel {
         self.cancellables = []
         self.busArriveInfos = []
         self.busStationInfos = []
+        self.errorMessage = nil
         self.binding()
         self.refresh()
         self.configureObserver()
@@ -115,5 +117,9 @@ class AlarmSettingViewModel {
             .collect()
             .assign(to: \.busStationInfos, on: self)
             .store(in: &self.cancellables)
+    }
+    
+    func sendErrorMessage(_ message: String) {
+        self.errorMessage = message
     }
 }

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -124,3 +124,9 @@ extension AppCoordinator: CoordinatorFinishDelegate {
         }
     }
 }
+
+extension AppCoordinator: CoordinatorAlertDelegate {
+    func pushAlert(controller: UIAlertController, completion: (() -> Void)? = nil) {
+        self.navigationPresenter.present(controller, animated: false, completion: completion)
+    }
+}

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -19,7 +19,11 @@ protocol CoordinatorCreateDelegate {
     func pushStation(arsId: String)
 }
 
-typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDelegate)
+protocol CoordinatorAlertDelegate {
+    func pushAlert(controller: UIAlertController, completion: (() -> Void)?)
+}
+
+typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDelegate & CoordinatorAlertDelegate)
 
 protocol Coordinator: AnyObject {
     var navigationPresenter: UINavigationController { get set }

--- a/BBus/BBus/Global/Coordinator/Pushables.swift
+++ b/BBus/BBus/Global/Coordinator/Pushables.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 protocol BusRoutePushable: Coordinator {
     func pushToBusRoute(busRouteId: Int)
@@ -44,5 +45,15 @@ protocol StationPushable: Coordinator {
 extension StationPushable {
     func pushToStation(arsId: String) {
         self.delegate?.pushStation(arsId: arsId)
+    }
+}
+
+protocol AlertPushable: Coordinator {
+    func pushAlert(controller: UIAlertController, completion: (() -> Void)?)
+}
+
+extension AlertPushable {
+    func pushAlert(controller: UIAlertController, completion: (() -> Void)? = nil) {
+        self.delegate?.pushAlert(controller: controller, completion: completion)
     }
 }


### PR DESCRIPTION
## 작업 내용
- [x] 1번째 전 정거장에 버스가 위치할 경우 알람 등록이 되지 않으며 "버스가 곧 도착합니다"라는 메시지를 띄운다.
    - [x] 앱 코디네이터에서 AlertController를 띄울 수 있도록 delegate 생성
    - [x] 1번째 전 정거장일 시 체크

## 시연 방법
1번째, 0번째 전 정거장이거나, 곧도착일 시 승차알람 설정이 되지 않음
![Simulator Screen Recording - iPhone 12 - 2021-11-17 at 18 07 19](https://user-images.githubusercontent.com/64150179/142170487-57016c3a-8d85-4c54-9c95-8bea5f5c4925.gif)

## 기타 (고민과 해결, 리뷰 포인트 등)
