### PR TITLE
[승하차 알람] 11-6. 하차 정거장에 도착할 경우 "알람이 종료됩니다"라는 Alert 메세지를 띄우고 알람이 자동 종료된다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -1141,6 +1141,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BBus/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "하차 알람을 사용하기 위해서는 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1170,6 +1171,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BBus/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "하차 알람을 사용하기 위해서는 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/AlarmSetting/AlarmSettingViewController.swift
@@ -144,14 +144,14 @@ class AlarmSettingViewController: UIViewController {
         let controller = UIAlertController()
         let action = UIAlertAction(title: message, style: .cancel, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
     
     private func networkAlert() {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
 }
 

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -206,7 +206,7 @@ final class BusRouteViewController: UIViewController {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
     
     private func fetch() {

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -83,8 +83,12 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
 
 // MARK: - Delegate : AlertCreateDelegate
 extension AppCoordinator: AlertCreateDelegate {
-    func presentAlert(controller: UIAlertController, completion: (() -> Void)? = nil) {
+    func presentAlertToNavigation(controller: UIAlertController, completion: (() -> Void)? = nil) {
         self.navigationPresenter.present(controller, animated: false, completion: completion)
+    }
+
+    func presentAlertToMovingStatus(controller: UIAlertController, completion: (() -> Void)? = nil) {
+        self.movingStatusPresenter?.present(controller, animated: false, completion: completion)
     }
 }
 

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -20,7 +20,8 @@ protocol CoordinatorCreateDelegate {
 }
 
 protocol AlertCreateDelegate {
-    func presentAlert(controller: UIAlertController, completion: (() -> Void)?)
+    func presentAlertToNavigation(controller: UIAlertController, completion: (() -> Void)?)
+    func presentAlertToMovingStatus(controller: UIAlertController, completion: (() -> Void)?)
 }
 
 typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDelegate & AlertCreateDelegate)

--- a/BBus/BBus/Global/Coordinator/Pushables.swift
+++ b/BBus/BBus/Global/Coordinator/Pushables.swift
@@ -59,6 +59,6 @@ protocol AlertPresentable: Coordinator {
 
 extension AlertPresentable {
     func presentAlert(controller: UIAlertController, completion: (() -> Void)? = nil) {
-        self.delegate?.presentAlert(controller: controller, completion: completion)
+        self.delegate?.presentAlertToNavigation(controller: controller, completion: completion)
     }
 }

--- a/BBus/BBus/Home/HomeViewController.swift
+++ b/BBus/BBus/Home/HomeViewController.swift
@@ -130,7 +130,7 @@ class HomeViewController: UIViewController {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
 }
 

--- a/BBus/BBus/Info.plist
+++ b/BBus/BBus/Info.plist
@@ -2,25 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleDarkContent</string>
+	<key>NSLocationUsageDescription</key>
+	<string>뭐라고 해야할지 모르는 알림 내용</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>하차 알람을 사용하기 위해서는 위치 정보가 필요합니다.</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>ws.bus.go.kr</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
+	<string>하차 알람을 위해서 사용자의 GPS 위치를 추적해야합니다.</string>
 	<key>API_ACCESS_KEY1</key>
 	<string>${API_ACCESS_KEY1}</string>
 	<key>API_ACCESS_KEY2</key>
@@ -39,6 +24,19 @@
 	<string>${API_ACCESS_KEY8}</string>
 	<key>API_ACCESS_KEY9</key>
 	<string>${API_ACCESS_KEY9}</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>ws.bus.go.kr</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -56,5 +54,13 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDarkContent</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/BBus/BBus/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/MovingStatus/MovingStatusViewController.swift
@@ -58,6 +58,10 @@ final class MovingStatusViewController: UIViewController {
         self.configureLocationManager()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+
     private func configureLocationManager() {
         // locationManager 인스턴스를 생성
         self.locationManager = CLLocationManager()
@@ -132,6 +136,7 @@ final class MovingStatusViewController: UIViewController {
         self.bindCurrentStation()
         self.bindStationInfos()
         self.bindBoardedBus()
+        self.bindIsTerminated()
     }
 
     private func bindHeaderBusInfo() {
@@ -192,6 +197,17 @@ final class MovingStatusViewController: UIViewController {
             .store(in: &self.cancellables)
     }
 
+    private func bindIsTerminated() {
+        self.viewModel?.$isterminated
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] isTerminated in
+                if isTerminated {
+                    self?.terminateAlert()
+                }
+            })
+            .store(in: &self.cancellables)
+    }
+
     private func configureBusColor(type: RouteType) {
         switch type {
         case .mainLine:
@@ -235,7 +251,16 @@ final class MovingStatusViewController: UIViewController {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.presentAlertToNavigation(controller: controller, completion: nil)
+    }
+
+    private func terminateAlert() {
+        let controller = UIAlertController(title: "하차 종료", message: "하차 정거장에 도착하여 알람이 종료되었습니다.", preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
+            self?.coordinator?.close()
+        })
+        controller.addAction(action)
+        self.coordinator?.presentAlertToMovingStatus(controller: controller, completion: nil)
     }
 }
 

--- a/BBus/BBus/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/MovingStatus/MovingStatusViewController.swift
@@ -69,7 +69,7 @@ final class MovingStatusViewController: UIViewController {
         self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
         
         // 백그라운드에서 위치 업데이트
-//        self.locationManager?.allowsBackgroundLocationUpdates = true
+        self.locationManager?.allowsBackgroundLocationUpdates = true
 
         // 위치 정보를 지속적으로 받고 싶은 경우 이벤트를 시작
         self.locationManager?.startUpdatingLocation()

--- a/BBus/BBus/MovingStatus/ViewModel/MovingStatusViewModel.swift
+++ b/BBus/BBus/MovingStatus/ViewModel/MovingStatusViewModel.swift
@@ -76,10 +76,10 @@ final class MovingStatusViewModel {
 
                 self?.buses = buses.filter { $0.sectionOrder >= currentOrd && $0.sectionOrder < startOrd + count } // 5
                 // Test 로직
-                guard let y = self?.buses.first?.gpsY,
-                      let x = self?.buses.first?.gpsX else { return }
-
-                self?.findBoardBus(gpsY: y, gpsX: x)
+//                guard let y = self?.buses.first?.gpsY,
+//                      let x = self?.buses.first?.gpsX else { return }
+//
+//                self?.findBoardBus(gpsY: y, gpsX: x)
             }
             .store(in: &self.cancellables)
     }
@@ -94,7 +94,7 @@ final class MovingStatusViewModel {
         self.busInfo = busInfo // 1
     }
 
-    // GPS 를 통해 현재 위치를 찾은 경우 사용되는 메소드
+    // Background 내에서 GPS 변화시 불리는 함수
     func findBoardBus(gpsY: Double, gpsX: Double) {
         if buses.isEmpty { return }
         if stationInfos.isEmpty { return }

--- a/BBus/BBus/Search/SearchViewController.swift
+++ b/BBus/BBus/Search/SearchViewController.swift
@@ -83,7 +83,7 @@ final class SearchViewController: UIViewController {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
 }
 

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -167,7 +167,7 @@ class StationViewController: UIViewController {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
         controller.addAction(action)
-        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+        self.coordinator?.delegate?.presentAlertToNavigation(controller: controller, completion: nil)
     }
 
     private func configureColor() {


### PR DESCRIPTION
## 작업 내용
- [x] 백그라운드 에서 주기적으로 API가 요청되어야 한다.
- [x] 하차 3정거장 이내일 경우 Push 알림을 보내야 한다.
- [x] 하차 정거장에 도착했을 경우 알림을 보내야 하며 API 요청로직이 정지되어야 한다.

## 시연 방법
- Background 에서 gps 를 fetch 할 수 있도록 project 및 info.plist 를 설정
- Background 가 살아있기에 15초 간 API를 fetch 할 수 있음
- 탑승된 boardedBus 가 판별되면 남은 정거장수를 업데이트 하는 `updateRemainingStation` 메소드가 실행
- 이후 remainingStation 값에 따라 push 로직을 처리하도록 구현
- 만약 하차 정거장에 도착하였을 경우 API 요청을 못하도록 처리
- ViewController 에서 또한 Alert를 띄우도록 처리
- 다시 화면에 돌아왔을 시 확인 버튼을 클릭하면 자동으로 MovinigStatusViewController 가 닫히도록 로직 작성

```Swift
// 남은 정거장 수 업데이트 로직
    private func updateRemainingStation(bus: BusPosByRtidDTO) {
        guard let startOrd = self.startOrd else { return }
        let remainStation = (self.stationInfos.count - 1) - (bus.sectionOrder - startOrd) // 6

        if self.remainingStation != remainStation {
            self.pushAlarm(remainStation: remainStation)
            self.remainingStation = remainStation
        }
    }
```
```Swift
// 정거장 수가 변화되었을 경우 알람 푸쉬 로직
    private func pushAlarm(remainStation: Int) {
        if remainStation < 4 && remainStation > 1 {
            // TODO: push 알림 보내기 구현
            print("\(remainStation) 정거장 남았어요!")
        }
        else if remainStation == 1 {
            // TODO: push 알림 보내기 구현
            print("다음 정거장에 내려야 합니다!")
        }
        else if remainStation <= 0 {
            // TODO: push 알림 보내기 구현
            print("하차 정거장에 도착하여 알람이 종료되었습니다.")
            self.isterminated = true
        }
    }
```


## 기타 (고민과 해결, 리뷰 포인트 등)
