### PR TITLE
[정거장 정보] 마을버스 클릭시 앱이 죽는 현상

### DIFF
--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -166,14 +166,7 @@ final class BusRouteViewController: UIViewController {
                     self?.configureBusColor(type: header.routeType)
                 }
                 else {
-                    let controller = UIAlertController(title: "정보가 제공되지 않는 버스",
-                                                       message: "죄송합니다. 현재 정보가 제공되지 않는 버스입니다.",
-                                                       preferredStyle: .alert)
-                    let action = UIAlertAction(title: "확인",
-                                               style: .default,
-                                               handler: { [weak self] _ in self?.coordinator?.terminate() })
-                    controller.addAction(action)
-                    self?.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+                    self?.noInfoAlert()
                 }
             })
             .store(in: &self.cancellables)
@@ -215,6 +208,17 @@ final class BusRouteViewController: UIViewController {
     private func networkAlert() {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
+        controller.addAction(action)
+        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
+    }
+    
+    private func noInfoAlert() {
+        let controller = UIAlertController(title: "버스 에러",
+                                           message: "죄송합니다. 현재 정보가 제공되지 않는 버스입니다.",
+                                           preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인",
+                                   style: .default,
+                                   handler: { [weak self] _ in self?.coordinator?.terminate() })
         controller.addAction(action)
         self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
     }

--- a/BBus/BBus/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/BusRoute/BusRouteViewController.swift
@@ -154,16 +154,26 @@ final class BusRouteViewController: UIViewController {
 
     private func bindingBusRouteHeaderResult() {
         self.viewModel?.$header
-            .receive(on: BusRouteUsecase.queue)
+            .receive(on: DispatchQueue.main)
+            .dropFirst()
             .sink(receiveValue: { [weak self] header in
-                guard let header = header else { return }
-                DispatchQueue.main.async {
+                if let header = header {
                     self?.customNavigationBar.configureBackButtonTitle(header.busRouteName)
                     self?.busRouteView.configureHeaderView(busType: header.routeType.rawValue+"버스",
                                                           busNumber: header.busRouteName,
                                                           fromStation: header.startStation,
                                                           toStation: header.endStation)
                     self?.configureBusColor(type: header.routeType)
+                }
+                else {
+                    let controller = UIAlertController(title: "정보가 제공되지 않는 버스",
+                                                       message: "죄송합니다. 현재 정보가 제공되지 않는 버스입니다.",
+                                                       preferredStyle: .alert)
+                    let action = UIAlertAction(title: "확인",
+                                               style: .default,
+                                               handler: { [weak self] _ in self?.coordinator?.terminate() })
+                    controller.addAction(action)
+                    self?.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
                 }
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
+++ b/BBus/BBus/BusRoute/UseCase/BusRouteUseCase.swift
@@ -28,9 +28,8 @@ final class BusRouteUsecase {
         self.usecases.getRouteList()
             .receive(on: Self.queue)
             .decode(type: [BusRouteDTO].self, decoder: JSONDecoder())
-            .tryMap({ routeList -> BusRouteDTO in
-                let headers = routeList.filter { $0.routeID == busRouteId }
-                guard let header = headers.first else { throw BBusAPIError.wrongFormatError }
+            .tryMap({ routeList -> BusRouteDTO? in
+                let header = routeList.filter { $0.routeID == busRouteId }.first
                 return header
             })
             .retry({ [weak self] in

--- a/BBus/BBus/Station/StationViewController.swift
+++ b/BBus/BBus/Station/StationViewController.swift
@@ -117,11 +117,14 @@ class StationViewController: UIViewController {
             }.store(in: &self.cancellables)
         
         self.viewModel?.usecase.$stationInfo
-            .receive(on: StationUsecase.queue)
+            .receive(on: DispatchQueue.main)
+            .dropFirst()
             .sink(receiveValue: { [weak self] station in
-                DispatchQueue.main.async {
-                    guard let station = station else { return }
+                if let station = station {
                     self?.stationView.configureHeaderView(stationId: station.arsID, stationName: station.stationName)
+                }
+                else {
+                    self?.noInfoAlert()
                 }
             })
             .store(in: &self.cancellables)
@@ -172,6 +175,17 @@ class StationViewController: UIViewController {
 
     private func configureColor() {
         self.view.backgroundColor = BBusColor.bbusGray
+    }
+    
+    private func noInfoAlert() {
+        let controller = UIAlertController(title: "정거장 에러",
+                                           message: "죄송합니다. 현재 정보가 제공되지 않는 정거장입니다.",
+                                           preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인",
+                                   style: .default,
+                                   handler: { [weak self] _ in self?.coordinator?.terminate() })
+        controller.addAction(action)
+        self.coordinator?.delegate?.presentAlert(controller: controller, completion: nil)
     }
 }
 

--- a/BBus/BBus/Station/UseCase/StationUseCase.swift
+++ b/BBus/BBus/Station/UseCase/StationUseCase.swift
@@ -35,8 +35,7 @@ class StationUsecase {
             .receive(on: Self.queue)
             .decode(type: [StationDTO].self, decoder: JSONDecoder())
             .tryMap({ [weak self] stations in
-                guard let result = self?.findStation(in: stations, with: arsId) else { throw BBusAPIError.wrongFormatError }
-                return result
+                return self?.findStation(in: stations, with: arsId)
             })
             .retry({ [weak self] in
                 self?.stationInfoWillLoad(with: arsId)


### PR DESCRIPTION
## 작업 내용
- [x] #137 해결

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 구현 방식
  - 일단 노선도화면/정거장화면으로 진입한 뒤, 로컬 json에서 id로 filter한 결과가 nil일 경우 alert를 띄우고, coordinator.terminate 하게 함.
- 모든 버스와 정거장에서 alert가 뜨는 문제 
  - @Published 프로퍼티를 쓸 경우 최초 init된 값인 nil이 한번 publish되기 때문에 모든 버스와 정거장에서 alert이 뜨는 문제가 있었음.
  - `dropFirst()`로 이후 값만 리시브하도록 함.