### PR TITLE
[리뷰 반영] #227 11-6. 하차 정거장에 도착할 경우 "알람이 종료됩니다"라는 Alert 메세지를 띄우고 알람이 자동 종료된다.

### DIFF
--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -58,10 +58,6 @@ final class MovingStatusViewController: UIViewController {
         self.configureLocationManager()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-    }
-
     private func configureLocationManager() {
         // locationManager 인스턴스를 생성
         self.locationManager = CLLocationManager()

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 import CoreLocation
 
-typealias MovingStatusCoordinator = MovingStatusOpenCloseDelegate & MovingStatusFoldUnfoldDelegate & AlertCreateDelegate
+typealias MovingStatusCoordinator = MovingStatusOpenCloseDelegate & MovingStatusFoldUnfoldDelegate & AlertCreateToNavigationDelegate & AlertCreateToMovingStatusDelegate
 
 final class MovingStatusViewController: UIViewController {
 

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -256,7 +256,14 @@ final class MovingStatusViewController: UIViewController {
             self?.coordinator?.close()
         })
         controller.addAction(action)
-        self.coordinator?.presentAlertToMovingStatus(controller: controller, completion: nil)
+
+        guard let isFolded = self.viewModel?.isFolded else { return }
+        if isFolded {
+            self.coordinator?.presentAlertToNavigation(controller: controller, completion: nil)
+        }
+        else {
+            self.coordinator?.presentAlertToMovingStatus(controller: controller, completion: nil)
+        }
     }
 }
 
@@ -293,6 +300,7 @@ extension MovingStatusViewController: BottomIndicatorButtonDelegate {
         // Coordinator에게 Unfold 요청
         print("bottom indicator button is touched")
         UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.viewModel?.unfold()
             self?.coordinator?.unfold()
         }
     }
@@ -304,6 +312,7 @@ extension MovingStatusViewController: FoldButtonDelegate {
         // Coordinator에게 fold 요청
         print("fold button is touched")
         UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.viewModel?.fold()
             self?.coordinator?.fold()
         }
     }

--- a/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
+++ b/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
@@ -23,6 +23,7 @@ final class MovingStatusViewModel {
     private let toArsId: String
     private var startOrd: Int? // 2
     private var currentOrd: Int?
+    private(set) var isFolded: Bool = false
     @Published var isterminated: Bool = false
     @Published var busInfo: BusInfo? // 1
     @Published var stationInfos: [StationInfo] = [] // 3
@@ -231,5 +232,13 @@ final class MovingStatusViewModel {
     // 타이머가 일정주기로 실행
     func updateAPI() {
         self.usecase.fetchBusPosList(busRouteId: self.busRouteId) //고민 필요
+    }
+
+    func fold() {
+        self.isFolded = true
+    }
+
+    func unfold() {
+        self.isFolded = false
     }
 }

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -81,12 +81,15 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
     }
 }
 
-// MARK: - Delegate : AlertCreateDelegate
-extension AppCoordinator: AlertCreateDelegate {
+// MARK: - Delegate : AlertCreateToNavigation
+extension AppCoordinator: AlertCreateToNavigationDelegate {
     func presentAlertToNavigation(controller: UIAlertController, completion: (() -> Void)? = nil) {
         self.navigationPresenter.present(controller, animated: false, completion: completion)
     }
+}
 
+// MARK: - Delegate : AlertCreateToMovingStatus
+extension AppCoordinator: AlertCreateToMovingStatusDelegate {
     func presentAlertToMovingStatus(controller: UIAlertController, completion: (() -> Void)? = nil) {
         self.movingStatusPresenter?.present(controller, animated: false, completion: completion)
     }

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -19,12 +19,15 @@ protocol CoordinatorCreateDelegate: AnyObject {
     func pushStation(arsId: String)
 }
 
-protocol AlertCreateDelegate: AnyObject {
+protocol AlertCreateToNavigationDelegate: AnyObject {
     func presentAlertToNavigation(controller: UIAlertController, completion: (() -> Void)?)
+}
+
+protocol AlertCreateToMovingStatusDelegate: AnyObject {
     func presentAlertToMovingStatus(controller: UIAlertController, completion: (() -> Void)?)
 }
 
-typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDelegate & AlertCreateDelegate)
+typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDelegate & AlertCreateToNavigationDelegate)
 
 protocol Coordinator: AnyObject {
     var navigationPresenter: UINavigationController { get set }

--- a/BBus/BBus/Info.plist
+++ b/BBus/BBus/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSLocationUsageDescription</key>
-	<string>뭐라고 해야할지 모르는 알림 내용</string>
+	<string>하차 알람을 위해서 사용자의 GPS 위치를 추적해야합니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>하차 알람을 위해서 사용자의 GPS 위치를 추적해야합니다.</string>
 	<key>API_ACCESS_KEY1</key>


### PR DESCRIPTION
## 작업 내용
- [x] AlertCreateToMovingStatusDelegate 프로토콜 분리 작업
- [x] NSLocationUsageDescription 메세지 수정
- [x] viewWillAppear 제거
- [x] fold, unfold 상태에 따른 alert 로직분리 작업 

## 시연 방법
- fold, unfold 상태에 따른 alert 로직 에러 확인하여 로직을 추가하였음

| unfold 상태 | fold 상태 |
| -------- | -------- |
| <img src="https://i.imgur.com/QL5EJOT.gif"> |<img src="https://i.imgur.com/wWmnpwW.gif"> |

- viewModel 내에 `private(set) var isFolded: Bool = false` 변수를 추가
- 접히고 필때마다 값 변경
- 종료 alert 로직에서 변수 값에 따른 분기처리 추가
```Swift
guard let isFolded = self.viewModel?.isFolded else { return }
        if isFolded {
            self.coordinator?.presentAlertToNavigation(controller: controller, completion: nil)
        }
        else {
            self.coordinator?.presentAlertToMovingStatus(controller: controller, completion: nil)
        }
```

## 기타 (고민과 해결, 리뷰 포인트 등)
