### PR TITLE
[정거장 정보] 즐겨찾기 추가/해제 시 화면이 깜빡이는 현상

### DIFF
--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -150,6 +150,8 @@ class StationViewController: UIViewController {
         
         self.viewModel?.$favoriteItems
             .receive(on: StationUsecase.queue)
+            .compactMap { $0 }
+            .first()
             .sink(receiveValue: { [weak self] _ in
                 DispatchQueue.main.async {
                     self?.stationView.reload()


### PR DESCRIPTION
## 작업 내용
- [x] 화면 깜빡이지 않도록 수정

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 별모양 버튼 터치 시 favoriteItems가 변경됨
- favoriteItems가 변경되면 reload 되도록 바인딩이 걸려있음.
- reload 대신 버튼 색상만 다시 configure 하도록 바인딩하여 reload 때문에 깜빡이는 현상을 해결함.
- 그런데 문제는 최초로 favoriteItems를 불러왔을 때는 reload를 해야된다는 점.
- 아래와 같이 최초로 receive 했을 때만 reload 하도록 `first()` 오퍼레이터를 걸어줌.
  ``` swift
  self.viewModel?.$favoriteItems
            .receive(on: StationUsecase.queue)
            .compactMap { $0 }
            .first()
            .sink(receiveValue: { [weak self] _ in
                DispatchQueue.main.async {
                    self?.stationView.reload()
                }
            })
            .store(in: &self.cancellables)  
  ``` 