### PR TITLE
[갱신] 무한 push로 쌓인 화면들에서도 자동갱신 때문에 api를 요청하는 문제

### DIFF
--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
@@ -48,6 +48,17 @@ class AlarmSettingViewController: UIViewController {
         
         self.binding()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewModel?.configureObserver()
+        self.viewModel?.refresh()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.viewModel?.cancleObserver()
+    }
     
     // MARK: - Configure
     private func configureLayout() {

--- a/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
@@ -33,6 +33,16 @@ final class BusRouteViewController: UIViewController {
         return button
     }()
 
+    init(viewModel: BusRouteViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.viewModel = nil
+        super.init(coder: coder)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -43,14 +53,15 @@ final class BusRouteViewController: UIViewController {
         self.fetch()
     }
 
-    init(viewModel: BusRouteViewModel) {
-        self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewModel?.configureObserver()
+        self.viewModel?.refreshBusPos()
     }
 
-    required init?(coder: NSCoder) {
-        self.viewModel = nil
-        super.init(coder: coder)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.viewModel?.cancleObserver()
     }
 
     // MARK: - Configure

--- a/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -28,13 +28,14 @@ final class BusRouteViewModel {
         self.bindingHeaderInfo()
         self.bindingBodysInfo()
         self.bindingBusesPosInfo()
-        self.configureObserver()
     }
 
-    private func configureObserver() {
-        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .none) { [weak self] _ in
-            self?.refreshBusPos()
-        }
+    func configureObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshBusPos), name: .thirtySecondPassed, object: nil)
+    }
+
+    func cancleObserver() {
+        NotificationCenter.default.removeObserver(self)
     }
 
     private func bindingHeaderInfo() {
@@ -117,7 +118,7 @@ final class BusRouteViewModel {
         self.usecase.fetchRouteList(busRouteId: self.busRouteId)
     }
 
-    func refreshBusPos() {
+    @objc func refreshBusPos() {
         self.usecase.fetchBusPosList(busRouteId: self.busRouteId)
     }
 }

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -70,6 +70,12 @@ class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.viewModel?.reloadFavoriteData()
+        self.viewModel?.configureObserver()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.viewModel?.cancleObserver()
     }
 
     // MARK: - Configuration

--- a/BBus/BBus/Foreground/Home/ViewModel/HomeViewModel.swift
+++ b/BBus/BBus/Foreground/Home/ViewModel/HomeViewModel.swift
@@ -17,19 +17,18 @@ class HomeViewModel {
     init(useCase: HomeUseCase) {
         self.useCase = useCase
         self.bindFavoriteData()
-        self.configureObserver()
     }
 
-    private func configureObserver() {
-        NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { _ in
-            self.descendTime()
-        }
-        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .main) { _ in
-            self.reloadFavoriteData()
-        }
+    func configureObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(descendTime), name: .oneSecondPassed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadFavoriteData), name: .thirtySecondPassed, object: nil)
     }
 
-    private func descendTime() {
+    func cancleObserver() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func descendTime() {
         self.homeFavoriteList?.descendAllTime()
     }
 
@@ -49,7 +48,7 @@ class HomeViewModel {
             })
     }
 
-    func reloadFavoriteData() {
+    @objc func reloadFavoriteData() {
         self.useCase.loadFavoriteData()
     }
 

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -67,6 +67,17 @@ class StationViewController: UIViewController {
         self.configureDelegate()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewModel?.configureObserver()
+        self.viewModel?.refresh()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.viewModel?.cancleObserver()
+    }
+
     // MARK: - Configure
     private func configureLayout() {
         let refreshButtonWidthAnchor: CGFloat = 50

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -30,24 +30,23 @@ class StationViewModel {
         self.busKeys = []
         self.binding()
         self.refresh()
-        self.configureObserver()
     }
 
-    private func configureObserver() {
-        NotificationCenter.default.addObserver(forName: .oneSecondPassed, object: nil, queue: .main) { [weak self] _ in
-            self?.descendTime()
-        }
-        NotificationCenter.default.addObserver(forName: .thirtySecondPassed, object: nil, queue: .main) { [weak self] _ in
-            self?.refresh()
-        }
+    func configureObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(descendTime), name: .oneSecondPassed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refresh), name: .thirtySecondPassed, object: nil)
+    }
+
+    func cancleObserver() {
+        NotificationCenter.default.removeObserver(self)
     }
     
-    func refresh() {
+    @objc func refresh() {
         self.usecase.stationInfoWillLoad(with: arsId)
         self.usecase.refreshInfo(about: arsId)
     }
 
-    private func descendTime() {
+    @objc private func descendTime() {
         self.infoBuses.forEach({ [weak self] in
             self?.infoBuses[$0.key] = $0.value.map { result in
                 var remainTime = result


### PR DESCRIPTION
## 작업 내용
- [x] view will appear 시 observer 등록, 최신데이터 fetch
- [x] view will disappear 시 observer 제거

## 시연 방법
- `NotificationCenter.default.removeObserver(self)` 메소드를 통해 Notification 에 등록된 observer 를 제거하는 식으로 누수되는 API 를 막았다.

## 기타 (고민과 해결, 리뷰 포인트 등)
