### PR TITLE
[버그] 하차알림 페이지 알람 버튼 클릭 시 화면 height관련 에러 해결

### DIFF
--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -63,7 +63,9 @@ extension AppCoordinator: MovingStatusFoldUnfoldDelegate {
 // MARK: - Delegate : MovingStatusOpenCloseDelegate
 extension AppCoordinator: MovingStatusOpenCloseDelegate {
     func open(busRouteId: Int, fromArsId: String, toArsId: String) {
-        self.navigationWindow.frame.size = CGSize(width: self.navigationWindow.frame.width, height: self.navigationWindow.frame.height - MovingStatusView.bottomIndicatorHeight)
+        if self.movingStatusWindow.isHidden {
+            self.navigationWindow.frame.size = CGSize(width: self.navigationWindow.frame.width, height: self.navigationWindow.frame.height - MovingStatusView.bottomIndicatorHeight)
+        }
         
         let usecase = MovingStatusUsecase(usecases: BBusAPIUsecases(on: MovingStatusUsecase.queue))
         let viewModel = MovingStatusViewModel(usecase: usecase, busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)


### PR DESCRIPTION
## 작업 내용
- [x] 하차알림 페이지 알람 버튼 클릭 시 화면 height관련 에러 해결

## 시연 방법
![Simulator Screen Recording - iPhone 12 - 2021-11-24 at 15 35 48](https://user-images.githubusercontent.com/64150179/143187223-357a9965-f84c-4d64-93e3-8893084a19a8.gif)

## 기타 (고민과 해결, 리뷰 포인트 등)
movingStatusWindow가 hidden이 아닐 경우 height를 변경하지 않도록 하여 해결

close #262 