### PR TITLE
[갱신] 1초 타이머에서 2초씩 깎이는 현상

### DIFF
--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -113,7 +113,7 @@ class HomeViewController: UIViewController {
         self.viewModel?.$homeFavoriteList
             .compactMap { $0 }
             .filter { !$0.changedByTimer }
-            .receive(on: DispatchQueue.main)
+            .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink(receiveValue: { [weak self] response in
                 let isFavoriteEmpty = response.count() == 0
                 self?.homeView.emptyNoticeActivate(by: isFavoriteEmpty)


### PR DESCRIPTION
## 작업 내용
- [x] 1초 타이머에서 2초씩 깎이는 현상 발생하지 않음을 확인
- [x] 추가로 안전을 위해 홈 화면에서 reload에 debounce를 걸어둠

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 기존에는 2n번 reload되는 로직이어서 throttle을 걸어두었었음. -> throttle 때문에 중간에 씹혀서 2초가 한번에 깎였던 것으로 추측
- 각 셀을 개별적으로 매 초 configure하는 것으로 바꾸어 저절로 해결이 된 것 같음
- 모든 화면에 대해 2분이상 관찰하였는데 2초씩 깎이는 현상은 일어나지 않았음.
- home 화면의 경우 자동/수동 새로고침을 할 때마다 2n+2번의 reload가 일어나는 이슈가 남아있어 혹시 모를 상황을 대비해 debounce를 0.1초로 걸어두었음.