### PR TITLE
[승하차 알람] 10-4. 하차 알림이 설정되어있는 경우 알람 버튼이 빨간색으로 표시되어야 한다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -102,7 +102,10 @@
 		4ADB29CB274B7AB900554A4E /* GetOnAlarmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29CA274B7AB900554A4E /* GetOnAlarmViewModel.swift */; };
 		4ADB29CD274B880C00554A4E /* BusApproachCheckUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29CC274B880C00554A4E /* BusApproachCheckUsecase.swift */; };
 		4ADB29CF274B890800554A4E /* BusApproachStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29CE274B890800554A4E /* BusApproachStatus.swift */; };
-		4ADB29D1274CAF0100554A4E /* GetOnStartResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29D0274CAF0100554A4E /* GetOnStartResult.swift */; };
+		4ADB29D1274CAF0100554A4E /* AlarmStartResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29D0274CAF0100554A4E /* AlarmStartResult.swift */; };
+		4ADB29D4274E18BB00554A4E /* GetOffAlarmController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29D3274E18BB00554A4E /* GetOffAlarmController.swift */; };
+		4ADB29D7274E198900554A4E /* GetOffAlarmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29D6274E198900554A4E /* GetOffAlarmViewModel.swift */; };
+		4ADB29DA274E1A5F00554A4E /* GetOffAlarmStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29D9274E1A5F00554A4E /* GetOffAlarmStatus.swift */; };
 		87038A82273B90A50078EAE3 /* BBusAPIUsecases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87038A81273B90A50078EAE3 /* BBusAPIUsecases.swift */; };
 		87038A85273B90D10078EAE3 /* RequestUsecases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87038A84273B90D10078EAE3 /* RequestUsecases.swift */; };
 		87038A88273B950B0078EAE3 /* GetArrInfoByRouteListFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87038A87273B950B0078EAE3 /* GetArrInfoByRouteListFetcher.swift */; };
@@ -236,7 +239,10 @@
 		4ADB29CA274B7AB900554A4E /* GetOnAlarmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOnAlarmViewModel.swift; sourceTree = "<group>"; };
 		4ADB29CC274B880C00554A4E /* BusApproachCheckUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusApproachCheckUsecase.swift; sourceTree = "<group>"; };
 		4ADB29CE274B890800554A4E /* BusApproachStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusApproachStatus.swift; sourceTree = "<group>"; };
-		4ADB29D0274CAF0100554A4E /* GetOnStartResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOnStartResult.swift; sourceTree = "<group>"; };
+		4ADB29D0274CAF0100554A4E /* AlarmStartResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmStartResult.swift; sourceTree = "<group>"; };
+		4ADB29D3274E18BB00554A4E /* GetOffAlarmController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOffAlarmController.swift; sourceTree = "<group>"; };
+		4ADB29D6274E198900554A4E /* GetOffAlarmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOffAlarmViewModel.swift; sourceTree = "<group>"; };
+		4ADB29D9274E1A5F00554A4E /* GetOffAlarmStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOffAlarmStatus.swift; sourceTree = "<group>"; };
 		87038A81273B90A50078EAE3 /* BBusAPIUsecases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BBusAPIUsecases.swift; sourceTree = "<group>"; };
 		87038A84273B90D10078EAE3 /* RequestUsecases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUsecases.swift; sourceTree = "<group>"; };
 		87038A87273B950B0078EAE3 /* GetArrInfoByRouteListFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArrInfoByRouteListFetcher.swift; sourceTree = "<group>"; };
@@ -685,6 +691,7 @@
 			isa = PBXGroup;
 			children = (
 				4ADB29C5274B7A5500554A4E /* GetOnAlarm */,
+				4ADB29D2274E17B100554A4E /* GetOffAlarm */,
 			);
 			path = Background;
 			sourceTree = "<group>";
@@ -702,7 +709,7 @@
 			children = (
 				4ADB29C6274B7A7F00554A4E /* GetOnAlarmStatus.swift */,
 				4ADB29CE274B890800554A4E /* BusApproachStatus.swift */,
-				4ADB29D0274CAF0100554A4E /* GetOnStartResult.swift */,
+				4ADB29D0274CAF0100554A4E /* AlarmStartResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -725,6 +732,32 @@
 				4ADB29C2274B79E500554A4E /* ViewModel */,
 			);
 			path = GetOnAlarm;
+			sourceTree = "<group>";
+		};
+		4ADB29D2274E17B100554A4E /* GetOffAlarm */ = {
+			isa = PBXGroup;
+			children = (
+				4ADB29D3274E18BB00554A4E /* GetOffAlarmController.swift */,
+				4ADB29D8274E1A5500554A4E /* Model */,
+				4ADB29D5274E197E00554A4E /* ViewModel */,
+			);
+			path = GetOffAlarm;
+			sourceTree = "<group>";
+		};
+		4ADB29D5274E197E00554A4E /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				4ADB29D6274E198900554A4E /* GetOffAlarmViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		4ADB29D8274E1A5500554A4E /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				4ADB29D9274E1A5F00554A4E /* GetOffAlarmStatus.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		87038A80273B90810078EAE3 /* Network */ = {
@@ -914,6 +947,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4ACA5231272FCEE600EC0531 /* MovingStatusView.swift in Sources */,
+				4ADB29D7274E198900554A4E /* GetOffAlarmViewModel.swift in Sources */,
 				4ACA51EF272FCDE600EC0531 /* StationSearchResult.swift in Sources */,
 				4A17CED92733B5C6007B1646 /* SearchResultScrollView.swift in Sources */,
 				4ACA523B272FCF3C00EC0531 /* AlarmSettingViewController.swift in Sources */,
@@ -944,6 +978,7 @@
 				87038A82273B90A50078EAE3 /* BBusAPIUsecases.swift in Sources */,
 				4ACA51E3272FCD9600EC0531 /* HomeModel.swift in Sources */,
 				4ACA51E9272FCDAE00EC0531 /* HomeView.swift in Sources */,
+				4ADB29D4274E18BB00554A4E /* GetOffAlarmController.swift in Sources */,
 				4A06AEC8274159D10027222D /* FavoriteItemDTO.swift in Sources */,
 				4ACA521F272FCEAA00EC0531 /* AlarmSettingBusArriveInfo.swift in Sources */,
 				4A1A22DB27326FD100476861 /* HomeNavigationView.swift in Sources */,
@@ -997,6 +1032,7 @@
 				4ADB29BB274B6C8300554A4E /* BusPosByVehicleIdDTO.swift in Sources */,
 				049B9D002744D2AA004DE66E /* ThrottleButton.swift in Sources */,
 				4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */,
+				4ADB29DA274E1A5F00554A4E /* GetOffAlarmStatus.swift in Sources */,
 				4A7BBFED2737885F0029915F /* StationHeaderView.swift in Sources */,
 				049375B5273BB98E0061ACDA /* StationByRouteListDTO.swift in Sources */,
 				4A094CE127438EB800428F55 /* UIViewExtension.swift in Sources */,
@@ -1014,7 +1050,7 @@
 				87038A90273C11630078EAE3 /* GetStationsByRouteListFetcher.swift in Sources */,
 				4ACA522B272FCED600EC0531 /* MovingStatusModel.swift in Sources */,
 				4A917DF427463666002489FE /* EmptySearchResultNoticeView.swift in Sources */,
-				4ADB29D1274CAF0100554A4E /* GetOnStartResult.swift in Sources */,
+				4ADB29D1274CAF0100554A4E /* AlarmStartResult.swift in Sources */,
 				87A5556E2728116400A9B5E3 /* SceneDelegate.swift in Sources */,
 				04C6D6692734B18A00D41678 /* MovingStatusTableViewCell.swift in Sources */,
 				87359B8D27311BF100F461A7 /* BusTagView.swift in Sources */,

--- a/BBus/BBus/Background/GetOffAlarm/GetOffAlarmController.swift
+++ b/BBus/BBus/Background/GetOffAlarm/GetOffAlarmController.swift
@@ -16,7 +16,7 @@ final class GetOffAlarmController: NSObject {
 
     private override init() { }
 
-    func start(targetOrd: Int, busRouteId: Int, arsId: Int) -> AlarmStartResult {
+    func start(targetOrd: Int, busRouteId: Int, arsId: String) -> AlarmStartResult {
         if let viewModel = viewModel {
             return viewModel.causesStartFail(targetOrd: targetOrd, busRouteId: busRouteId)
         }

--- a/BBus/BBus/Background/GetOffAlarm/GetOffAlarmController.swift
+++ b/BBus/BBus/Background/GetOffAlarm/GetOffAlarmController.swift
@@ -1,0 +1,36 @@
+//
+//  GetOffAlarmController.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/24.
+//
+
+import Foundation
+import Combine
+
+final class GetOffAlarmController: NSObject {
+
+    static let shared = GetOffAlarmController()
+
+    @Published private(set) var viewModel: GetOffAlarmViewModel?
+
+    private override init() { }
+
+    func start(targetOrd: Int, busRouteId: Int, arsId: Int) -> AlarmStartResult {
+        if let viewModel = viewModel {
+            return viewModel.causesStartFail(targetOrd: targetOrd, busRouteId: busRouteId)
+        }
+        else {
+            let getOffAlarmStatus = GetOffAlarmStatus(targetOrd: targetOrd,
+                                                      busRouteId: busRouteId,
+                                                      arsId: arsId)
+            self.viewModel = GetOffAlarmViewModel(currentStatus: getOffAlarmStatus)
+            return .success
+        }
+    }
+
+    func stop() {
+        self.viewModel = nil
+    }
+
+}

--- a/BBus/BBus/Background/GetOffAlarm/Model/GetOffAlarmStatus.swift
+++ b/BBus/BBus/Background/GetOffAlarm/Model/GetOffAlarmStatus.swift
@@ -10,9 +10,9 @@ import Foundation
 struct GetOffAlarmStatus {
     let targetOrd: Int
     let busRouteId: Int
-    let arsId: Int
+    let arsId: String
 
-    init(targetOrd: Int, busRouteId: Int, arsId: Int) {
+    init(targetOrd: Int, busRouteId: Int, arsId: String) {
         self.targetOrd = targetOrd
         self.busRouteId = busRouteId
         self.arsId = arsId

--- a/BBus/BBus/Background/GetOffAlarm/Model/GetOffAlarmStatus.swift
+++ b/BBus/BBus/Background/GetOffAlarm/Model/GetOffAlarmStatus.swift
@@ -1,0 +1,20 @@
+//
+//  GetOffAlarmStatus.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/24.
+//
+
+import Foundation
+
+struct GetOffAlarmStatus {
+    let targetOrd: Int
+    let busRouteId: Int
+    let arsId: Int
+
+    init(targetOrd: Int, busRouteId: Int, arsId: Int) {
+        self.targetOrd = targetOrd
+        self.busRouteId = busRouteId
+        self.arsId = arsId
+    }
+}

--- a/BBus/BBus/Background/GetOffAlarm/ViewModel/GetOffAlarmViewModel.swift
+++ b/BBus/BBus/Background/GetOffAlarm/ViewModel/GetOffAlarmViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  GetOffAlarmViewModel.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/24.
+//
+
+import Foundation
+import Combine
+
+class GetOffAlarmViewModel {
+
+    private(set) var getOffAlarmStatus: GetOffAlarmStatus
+
+    init(currentStatus: GetOffAlarmStatus) {
+        self.getOffAlarmStatus = currentStatus
+    }
+
+    func causesStartFail(targetOrd: Int, busRouteId: Int) -> AlarmStartResult {
+        if isSameAlarm(targetOrd: targetOrd, busRouteId: busRouteId) {
+            return .sameAlarm
+        }
+        else {
+            return .duplicated
+        }
+    }
+
+    private func isSameAlarm(targetOrd: Int, busRouteId: Int) -> Bool {
+        return self.getOffAlarmStatus.targetOrd == targetOrd && self.getOffAlarmStatus.busRouteId == busRouteId
+    }
+}

--- a/BBus/BBus/Background/GetOnAlarm/GetOnAlarmController.swift
+++ b/BBus/BBus/Background/GetOnAlarm/GetOnAlarmController.swift
@@ -23,7 +23,7 @@ final class GetOnAlarmController: NSObject {
     
     private override init() { }
 
-    func start(targetOrd: Int, vehicleId: Int, busName: String, busRouteId: Int, stationId: Int) -> GetOnStartResult {
+    func start(targetOrd: Int, vehicleId: Int, busName: String, busRouteId: Int, stationId: Int) -> AlarmStartResult {
         if self.viewModel != nil {
             if isSameAlarm(targetOrd: targetOrd, vehicleId: vehicleId) {
                 return .sameAlarm

--- a/BBus/BBus/Background/GetOnAlarm/Model/AlarmStartResult.swift
+++ b/BBus/BBus/Background/GetOnAlarm/Model/AlarmStartResult.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum GetOnStartResult {
+enum AlarmStartResult {
     case success
     case sameAlarm
     case duplicated

--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingCoordinator.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingCoordinator.swift
@@ -38,6 +38,10 @@ class AlarmSettingCoordinator: Coordinator {
     func openMovingStatus(busRouteId: Int, fromArsId: String, toArsId: String) {
         self.movingStatusDelegate?.open(busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)
     }
+
+    func resetMovingStatus(busRouteId: Int, fromArsId: String, toArsId: String) {
+        self.movingStatusDelegate?.reset(busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)
+    }
     
     func closeMovingStatus() {
         self.movingStatusDelegate?.close()

--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
@@ -267,6 +267,19 @@ extension AlarmSettingViewController: UITableViewDataSource {
                            description: indexPath.item == 0 ? "\(info.arsId)" : "\(info.arsId) | \(info.estimatedTime)분 소요",
                            type: indexPath.item == 0 ? .getOn : .waypoint)
             cell.configureDelegate(self)
+            GetOffAlarmController.shared.$viewModel
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] getOffAlarmViewModel in
+                    if let getOffAlarmViewModel = getOffAlarmViewModel,
+                       self?.viewModel?.busRouteId == getOffAlarmViewModel.getOffAlarmStatus.busRouteId,
+                       info.ord == getOffAlarmViewModel.getOffAlarmStatus.targetOrd {
+                        cell.configure(alarmButtonActive: true)
+                    }
+                    else {
+                        cell.configure(alarmButtonActive: false)
+                    }
+                }
+                .store(in: &cell.cancellables)
             return cell
         default:
             return UITableViewCell()

--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
@@ -344,10 +344,9 @@ extension AlarmSettingViewController: GetOffAlarmButtonDelegate {
               let indexPath = self.alarmSettingView.indexPath(for: cell),
               let startStationArsId = self.viewModel?.busStationInfos?.first?.arsId,
               let endStationArsId = self.viewModel?.busStationInfos?[indexPath.item].arsId,
-              let targetArsId = Int(endStationArsId),
               let targetOrd = self.viewModel?.busStationInfos?[indexPath.item].ord else { return }
 
-        let result = GetOffAlarmController.shared.start(targetOrd: targetOrd, busRouteId: busRouteId, arsId: targetArsId)
+        let result = GetOffAlarmController.shared.start(targetOrd: targetOrd, busRouteId: busRouteId, arsId: startStationArsId)
         switch result {
         case .success:
             UIView.animate(withDuration: 0.3) { [weak self] in
@@ -360,9 +359,9 @@ extension AlarmSettingViewController: GetOffAlarmButtonDelegate {
         case .duplicated:
             self.alarmSettingActionSheet(titleMessage: "이미 설정되어있는 하차알람이 있습니다.\n 재설정 하시겠습니까?", buttonMessage: "재설정") {
                 GetOffAlarmController.shared.stop()
-                _ = GetOffAlarmController.shared.start(targetOrd: targetOrd, busRouteId: busRouteId, arsId: targetArsId)
+                _ = GetOffAlarmController.shared.start(targetOrd: targetOrd, busRouteId: busRouteId, arsId: endStationArsId)
                 UIView.animate(withDuration: 0.3) { [weak self] in
-                    self?.coordinator?.resetMovingStatus(busRouteId: busRouteId, fromArsId: startStationArsId, toArsId: endStationArsId)
+                    self?.coordinator?.resetMovingStatus(busRouteId: busRouteId, fromArsId: startStationArsId, toArsId: startStationArsId)
                 }
             }
         }

--- a/BBus/BBus/Foreground/AlarmSetting/Model/AlarmSettingBusArriveInfos.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/Model/AlarmSettingBusArriveInfos.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-typealias AlarmSettingBusStationInfo = (arsId: String, name: String, estimatedTime: Int)
+typealias AlarmSettingBusStationInfo = (arsId: String, name: String, estimatedTime: Int, ord: Int)
 
 struct AlarmSettingBusArriveInfos {
     var arriveInfos: [AlarmSettingBusArriveInfo]

--- a/BBus/BBus/Foreground/AlarmSetting/View/GetOffTableViewCell.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/View/GetOffTableViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 protocol GetOffAlarmButtonDelegate: AnyObject {
     func shouldGoToMovingStatusScene(from cell: UITableViewCell)
@@ -15,9 +16,11 @@ class GetOffTableViewCell: BusStationTableViewCell {
     enum BusRootCenterImageType {
         case waypoint, getOn
     }
-    
+
     static let reusableID = "GetOffTableViewCell"
     static let cellHeight: CGFloat = 80
+
+    var cancellables: Set<AnyCancellable> = []
     
     override var titleLeadingOffset: CGFloat { return 70 }
     override var lineTrailingOffset: CGFloat { return -35 }
@@ -30,8 +33,6 @@ class GetOffTableViewCell: BusStationTableViewCell {
         didSet {
             self.alarmButton.addAction(UIAction(handler: { [weak self] _ in
                 guard let self = self else { return }
-                
-                self.alarmButton.isSelected.toggle()
                 self.alarmButtonDelegate?.shouldGoToMovingStatusScene(from: self)
             }), for: .touchUpInside)
         }
@@ -47,6 +48,11 @@ class GetOffTableViewCell: BusStationTableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
+        self.cancellables.forEach { $0.cancel() }
+        self.cancellables.removeAll()
+
+        self.configure(alarmButtonActive: false)
+        self.configure(beforeColor: nil, afterColor: nil, title: "", description: "")
         self.alarmButton.removeTarget(nil, action: nil, for: .allEvents)
     }
     
@@ -106,5 +112,9 @@ class GetOffTableViewCell: BusStationTableViewCell {
     
     func configureDelegate(_ delegate: GetOffAlarmButtonDelegate) {
         self.alarmButtonDelegate = delegate
+    }
+
+    func configure(alarmButtonActive: Bool) {
+        self.alarmButton.isSelected = alarmButtonActive
     }
 }

--- a/BBus/BBus/Foreground/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -104,6 +104,7 @@ class AlarmSettingViewModel {
         initInfo.estimatedTime = 0
         initInfo.arsId = ""
         initInfo.name = ""
+        initInfo.ord = 0
 
         if let busStationsInfo = self.useCase.busStationsInfo {
             busStationsInfo.publisher
@@ -112,6 +113,7 @@ class AlarmSettingViewModel {
                     alarmSettingInfo.arsId = info.arsId
                     alarmSettingInfo.estimatedTime = before.estimatedTime + (before.arsId != "" ? MovingStatusViewModel.averageSectionTime(speed: info.sectionSpeed, distance: info.fullSectionDistance) : 0)
                     alarmSettingInfo.name = info.stationName
+                    alarmSettingInfo.ord = info.sectionOrd
                     return alarmSettingInfo
                 })
                 .collect()

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -204,11 +204,16 @@ extension HomeViewController: UICollectionViewDataSource {
         guard let model = self.viewModel?.homeFavoriteList?[indexPath.section]?[indexPath.item],
               let cellOrd = Int(model.favoriteItem.ord),
               let cellBusRouteId = Int(model.favoriteItem.busRouteId),
-              let cellStId = Int(model.favoriteItem.stId),
-              let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel else { return cell }
-        if getOnAlarmViewModel.getOnAlarmStatus.targetOrd == cellOrd,
-           getOnAlarmViewModel.getOnAlarmStatus.busRouteId == cellBusRouteId,
-           getOnAlarmViewModel.getOnAlarmStatus.stationId == cellStId {
+              let cellStId = Int(model.favoriteItem.stId) else { return cell }
+        let cellArsId = model.favoriteItem.arsId
+        let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel
+        let getOffAlarmViewModel = GetOffAlarmController.shared.viewModel
+        if (getOnAlarmViewModel?.getOnAlarmStatus.targetOrd == cellOrd &&
+            getOnAlarmViewModel?.getOnAlarmStatus.busRouteId == cellBusRouteId &&
+            getOnAlarmViewModel?.getOnAlarmStatus.stationId == cellStId) || (
+                getOffAlarmViewModel?.getOffAlarmStatus.arsId == cellArsId &&
+                getOffAlarmViewModel?.getOffAlarmStatus.busRouteId == cellBusRouteId
+            ) {
             cell.configure(alarmButtonActive: true)
         }
         else {

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -201,24 +201,19 @@ extension HomeViewController: UICollectionViewDataSource {
                 }
             })
             .store(in: &cell.cancellables)
-        GetOnAlarmController.shared.$viewModel
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self, weak cell] getOnAlarmViewModel in
-                guard let model = self?.viewModel?.homeFavoriteList?[indexPath.section]?[indexPath.item],
-                      let cellOrd = Int(model.favoriteItem.ord),
-                      let cellBusRouteId = Int(model.favoriteItem.busRouteId),
-                      let cellStId = Int(model.favoriteItem.stId) else { return }
-                if getOnAlarmViewModel?.getOnAlarmStatus.targetOrd == cellOrd,
-                   getOnAlarmViewModel?.getOnAlarmStatus.busRouteId == cellBusRouteId,
-                   getOnAlarmViewModel?.getOnAlarmStatus.stationId == cellStId {
-                    cell?.configure(alarmButtonActive: true)
-                }
-                else {
-                    cell?.configure(alarmButtonActive: false)
-                }
-
-            }
-            .store(in: &self.cancellables)
+        guard let model = self.viewModel?.homeFavoriteList?[indexPath.section]?[indexPath.item],
+              let cellOrd = Int(model.favoriteItem.ord),
+              let cellBusRouteId = Int(model.favoriteItem.busRouteId),
+              let cellStId = Int(model.favoriteItem.stId),
+              let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel else { return cell }
+        if getOnAlarmViewModel.getOnAlarmStatus.targetOrd == cellOrd,
+           getOnAlarmViewModel.getOnAlarmStatus.busRouteId == cellBusRouteId,
+           getOnAlarmViewModel.getOnAlarmStatus.stationId == cellStId {
+            cell.configure(alarmButtonActive: true)
+        }
+        else {
+            cell.configure(alarmButtonActive: false)
+        }
         
         return cell
     }

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusFoldUnfoldDelegate.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusFoldUnfoldDelegate.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol MovingStatusOpenCloseDelegate: AnyObject {
     func open(busRouteId: Int, fromArsId: String, toArsId: String)
+    func reset(busRouteId: Int, fromArsId: String, toArsId: String)
     func close()
 }
 

--- a/BBus/BBus/Foreground/Search/SearchViewController.swift
+++ b/BBus/BBus/Foreground/Search/SearchViewController.swift
@@ -145,11 +145,11 @@ extension SearchViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.identifier, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
         
         if collectionView.frame.origin.x == 0 {
-            guard let bus = self.viewModel?.searchResults.busSearchResults[indexPath.row] else { return UICollectionViewCell() }
+            guard let bus = self.viewModel?.searchResults.busSearchResults[indexPath.row] else { return cell }
             cell.configureBusUI(title: bus.busRouteName, detailInfo: bus.routeType)
         }
         else {
-            guard let station = self.viewModel?.searchResults.stationSearchResults[indexPath.row] else { return UICollectionViewCell() }
+            guard let station = self.viewModel?.searchResults.stationSearchResults[indexPath.row] else { return cell }
             cell.configureStationUI(title: station.stationName,
                                     titleMatchRanges: station.stationNameMatchRanges,
                                     arsId: station.arsId,

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -298,7 +298,7 @@ extension StationViewController: UICollectionViewDataSource {
                 }
 
             }
-            .store(in: &self.cancellables)
+            .store(in: &cell.cancellables)
         return cell
     }
 

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -275,6 +275,18 @@ extension StationViewController: UICollectionViewDataSource {
                     configureCell(busInfo)
                 })
                 .store(in: &cell.cancellables)
+
+            guard let key = self.viewModel?.busKeys[indexPath.section],
+                  let maxCount = self.viewModel?.infoBuses[key]?.count,
+                  let busInfo = maxCount > indexPath.item ? self.viewModel?.infoBuses[key]?[indexPath.item] : nil,
+                  let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel else { return cell }
+            if getOnAlarmViewModel.getOnAlarmStatus.targetOrd == busInfo.stationOrd,
+               getOnAlarmViewModel.getOnAlarmStatus.busRouteId == busInfo.busRouteId {
+                cell.configure(alarmButtonActive: true)
+            }
+            else {
+                cell.configure(alarmButtonActive: false)
+            }
         }
         // NoInfoBus인 경우: 바로 configure
         else {
@@ -284,21 +296,6 @@ extension StationViewController: UICollectionViewDataSource {
             }
         }
 
-        GetOnAlarmController.shared.$viewModel
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] getOnAlarmViewModel in
-                guard let key = self?.viewModel?.busKeys[indexPath.section],
-                      let model = self?.viewModel?.infoBuses[key]?[indexPath.item] else { return }
-                if getOnAlarmViewModel?.getOnAlarmStatus.targetOrd == model.stationOrd,
-                   getOnAlarmViewModel?.getOnAlarmStatus.busRouteId == model.busRouteId {
-                    cell.configure(alarmButtonActive: true)
-                }
-                else {
-                    cell.configure(alarmButtonActive: false)
-                }
-
-            }
-            .store(in: &cell.cancellables)
         return cell
     }
 

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -278,10 +278,14 @@ extension StationViewController: UICollectionViewDataSource {
 
             guard let key = self.viewModel?.busKeys[indexPath.section],
                   let maxCount = self.viewModel?.infoBuses[key]?.count,
-                  let busInfo = maxCount > indexPath.item ? self.viewModel?.infoBuses[key]?[indexPath.item] : nil,
-                  let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel else { return cell }
-            if getOnAlarmViewModel.getOnAlarmStatus.targetOrd == busInfo.stationOrd,
-               getOnAlarmViewModel.getOnAlarmStatus.busRouteId == busInfo.busRouteId {
+                  let busInfo = maxCount > indexPath.item ? self.viewModel?.infoBuses[key]?[indexPath.item] : nil  else { return cell }
+
+            let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel
+            let getOffAlarmViewModel = GetOffAlarmController.shared.viewModel
+            if (getOnAlarmViewModel?.getOnAlarmStatus.targetOrd == busInfo.stationOrd &&
+               getOnAlarmViewModel?.getOnAlarmStatus.busRouteId == busInfo.busRouteId) || (
+                getOffAlarmViewModel?.getOffAlarmStatus.arsId == self.viewModel?.arsId &&
+                getOffAlarmViewModel?.getOffAlarmStatus.busRouteId == busInfo.busRouteId) {
                 cell.configure(alarmButtonActive: true)
             }
             else {
@@ -384,11 +388,11 @@ extension StationViewController: LikeButtonDelegate {
         let item: FavoriteItemDTO
         if viewModel.infoBuses.count - 1 >= indexPath.section {
             guard let bus = viewModel.infoBuses[key]?[indexPath.item] else { return nil }
-            item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: "\(bus.arsId)")
+            item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: viewModel.arsId)
         }
         else {
             guard let bus = viewModel.noInfoBuses[key]?[indexPath.item] else { return nil }
-            item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: "\(bus.arsId)")
+            item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: viewModel.arsId)
         }
         return item
     }

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import UIKit
 
-typealias BusArriveInfo = (firstBusArriveRemainTime: BusRemainTime?, firstBusRelativePosition: String?, firstBusCongestion: BusCongestion?, secondBusArriveRemainTime: BusRemainTime?, secondBusRelativePosition: String?, secondBusCongestion: BusCongestion?, arsId: String, stationOrd: Int, busRouteId: Int, nextStation: String, busNumber: String, routeType: BBusRouteType)
+typealias BusArriveInfo = (firstBusArriveRemainTime: BusRemainTime?, firstBusRelativePosition: String?, firstBusCongestion: BusCongestion?, secondBusArriveRemainTime: BusRemainTime?, secondBusRelativePosition: String?, secondBusCongestion: BusCongestion?, stationOrd: Int, busRouteId: Int, nextStation: String, busNumber: String, routeType: BBusRouteType)
 
 
 class StationViewModel {
@@ -96,7 +96,6 @@ class StationViewModel {
             
             info.nextStation = bus.nextStation
             info.busNumber = bus.busNumber
-            info.arsId = bus.arsId
             info.stationOrd = bus.stationOrd
             info.busRouteId = bus.busRouteId
             

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -76,6 +76,19 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
             self?.unfold()
         }
     }
+
+    func reset(busRouteId: Int, fromArsId: String, toArsId: String) {
+        let usecase = MovingStatusUsecase(usecases: BBusAPIUsecases(on: MovingStatusUsecase.queue))
+        let viewModel = MovingStatusViewModel(usecase: usecase, busRouteId: busRouteId, fromArsId: fromArsId, toArsId: toArsId)
+        let viewController = MovingStatusViewController(viewModel: viewModel)
+        viewController.coordinator = self
+        self.movingStatusPresenter = viewController
+        self.movingStatusWindow.rootViewController = self.movingStatusPresenter
+        self.movingStatusWindow.isHidden = false
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.unfold()
+        }
+    }
     
     func close() {
         self.navigationWindow.frame.size = CGSize(width: self.navigationWindow.frame.width, height: self.navigationWindow.frame.height + MovingStatusView.bottomIndicatorHeight)
@@ -88,6 +101,7 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
             self.movingStatusPresenter = nil
             self.movingStatusWindow.rootViewController = nil
         })
+        GetOffAlarmController.shared.stop()
     }
 }
 


### PR DESCRIPTION
## 작업 내용
- [x] 같은 하차 알람을 누르면 하차알람 해제 actionSheet가 뜬다.
- [x] 다른 하차 알람을 누르면 재설정 actionSheet가 뜬다. 
- [x] 알람 세팅 화면의 알람 버튼이 하차 알람 상태에 따라 활성화 / 비활성화 된다.
- [x] 홈 화면의 알람 버튼이 하차 알람 상태에 따라 활성화 / 비활성화 된다.
- [x] 정거장 화면의 알람 버튼이 하차 알림 상태에 따라 활성화 / 비활성화 된다.
## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
* 하차 알람 중복 체크 로직을 어떻게 짜야할까?
1. MovingStatusViewController로 판단
    * coordinator를 통해 조회하는 방법 -> openMovingStatus에서 result 값으로 이미 있는지, 중복되는지, 없는지 판단해서 뿌려줌
        * 하지만 이 방법은 다른 뷰들이 알람이 생성되었다는 사실을 확인하기 위해서 coordinator에 접근해야하는데, 그에대한 로직을 coordinator로 짜기엔 조금 의도가 다르게 수행될 우려가 있음.
2. GetOnAlarmController처럼 singleton으로 확인
    * MovingStatusViewController가 항상 살아잇는데 그걸로 하면 되지 왜?
    * 홈 화면 및 정거장 화면에서도 이걸 접근해야하기 때문이다. MovingStatus로 하게 되면 너무 깊은 관게가 되어버리고 getOff와 로직이 너무 상이해지기에 헷갈릴 우려가 있다.
        * MovingStatusViewController로 확인하면 ViewModel에 바인딩 하기가 까다롭다.

* 결국 GetOffAlarmController를 하나 만들어서 싱글톤으로 관리하기로 결정



