### PR TITLE
[리뷰 반영] 다른 지역 버스에 대해 승하차 알람 화면 진입시 하차 알람 섹션이 뜨지 않음

### DIFF
--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
@@ -123,7 +123,9 @@ final class AlarmSettingViewController: UIViewController {
                     self?.alarmSettingView.reload()
                     if let viewModel = self?.viewModel,
                        let stationName = infos.first?.name {
-                        self?.customNavigationBar.configureTitle(busName: viewModel.busName, stationName: stationName, routeType: viewModel.routeType)
+                        self?.customNavigationBar.configureTitle(busName: viewModel.busName,
+                                                                 stationName: stationName,
+                                                                 routeType: viewModel.routeType)
                     }
                 }
                 else {

--- a/BBus/BBus/Foreground/AlarmSetting/UseCase/AlarmSettingUseCase.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/UseCase/AlarmSettingUseCase.swift
@@ -53,13 +53,10 @@ final class AlarmSettingUseCase {
             self.useCases.getStationsByRouteList(busRoutedId: busRouetId)
                 .receive(on: Self.queue)
                 .decode(type: StationByRouteResult.self, decoder: JSONDecoder())
-                // 에러를 throw하지 않고 nil을 반환하게 하여 retry가 필요하지 않음.
                 .retry({ [weak self] in
-                self?.busStationsInfoWillLoaded(busRouetId: busRouetId, arsId: arsId)
-
+                    self?.busStationsInfoWillLoaded(busRouetId: busRouetId, arsId: arsId)
                 }, handler: { [weak self] error in
                     self?.networkError = error
-
                 })
                 .map({ item in
                     let result = item.msgBody.itemList


### PR DESCRIPTION
## 작업 내용
- [x] 개행 추가

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- nil -> error로 리팩토링하는 것이 어떻냐는 피드백은 현재 구조로서는 크게 필요하지 않아 반영하지 않았음.
- 현재 구조: 로컬 json에 없는 버스는 아예 정거장 화면에서 보여주지 않으므로 서울버스 인데 서울시에서 정보를 제공해주지 않는 버스에 대해서만 처리하면 됨!
- 현재 서울버스 API가 개선된 것인지 웬만한 버스(마을버스, 파주버스.. 등) 에 대해 다 하차알람 섹션 정보가 제공이 되는 것으로 확인함.