### PR TITLE
[정거장 정보] ViewModel의 Collection 로 선언되어있는 property를 일급 컬렉션으로 추상화한다.

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA523C272FCF4300EC0531 /* MovingStatusViewController.swift */; };
 		4ACA5245272FD52D00EC0531 /* BBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5244272FD52D00EC0531 /* BBusTests.swift */; };
 		4ACC26B4274F669800173A32 /* BusSectionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC26B3274F669800173A32 /* BusSectionKeys.swift */; };
+		4ACC26B8274F6BD300173A32 /* BusArriveInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC26B7274F6BD300173A32 /* BusArriveInfos.swift */; };
 		4ADB29B9274B68CE00554A4E /* GetOnAlarmController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29B8274B68CE00554A4E /* GetOnAlarmController.swift */; };
 		4ADB29BB274B6C8300554A4E /* BusPosByVehicleIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29BA274B6C8300554A4E /* BusPosByVehicleIdDTO.swift */; };
 		4ADB29BD274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29BC274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift */; };
@@ -226,6 +227,7 @@
 		4ACA5242272FD52D00EC0531 /* BBusTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BBusTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ACA5244272FD52D00EC0531 /* BBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BBusTests.swift; sourceTree = "<group>"; };
 		4ACC26B3274F669800173A32 /* BusSectionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusSectionKeys.swift; sourceTree = "<group>"; };
+		4ACC26B7274F6BD300173A32 /* BusArriveInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusArriveInfos.swift; sourceTree = "<group>"; };
 		4ADB29B8274B68CE00554A4E /* GetOnAlarmController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOnAlarmController.swift; sourceTree = "<group>"; };
 		4ADB29BA274B6C8300554A4E /* BusPosByVehicleIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusPosByVehicleIdDTO.swift; sourceTree = "<group>"; };
 		4ADB29BC274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBusPosByVehIdFetcher.swift; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				4ACA5212272FCE8500EC0531 /* BusCongestion.swift */,
 				4A094CDE27435C5900428F55 /* BusRemainTime.swift */,
 				4ACC26B3274F669800173A32 /* BusSectionKeys.swift */,
+				4ACC26B7274F6BD300173A32 /* BusArriveInfos.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1010,6 +1013,7 @@
 				87EB52AE2733A6C6000D5492 /* GetOnStatusCell.swift in Sources */,
 				4A06AEE92743DAB20027222D /* NotificationNameExtension.swift in Sources */,
 				4ADB29BB274B6C8300554A4E /* BusPosByVehicleIdDTO.swift in Sources */,
+				4ACC26B8274F6BD300173A32 /* BusArriveInfos.swift in Sources */,
 				049B9D002744D2AA004DE66E /* ThrottleButton.swift in Sources */,
 				4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */,
 				4ADB29DA274E1A5F00554A4E /* GetOffAlarmStatus.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		4ACA523B272FCF3C00EC0531 /* AlarmSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA523A272FCF3C00EC0531 /* AlarmSettingViewController.swift */; };
 		4ACA523D272FCF4300EC0531 /* MovingStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA523C272FCF4300EC0531 /* MovingStatusViewController.swift */; };
 		4ACA5245272FD52D00EC0531 /* BBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5244272FD52D00EC0531 /* BBusTests.swift */; };
+		4ACC26B4274F669800173A32 /* BusSectionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC26B3274F669800173A32 /* BusSectionKeys.swift */; };
 		4ADB29B9274B68CE00554A4E /* GetOnAlarmController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29B8274B68CE00554A4E /* GetOnAlarmController.swift */; };
 		4ADB29BB274B6C8300554A4E /* BusPosByVehicleIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29BA274B6C8300554A4E /* BusPosByVehicleIdDTO.swift */; };
 		4ADB29BD274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB29BC274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift */; };
@@ -224,6 +225,7 @@
 		4ACA523C272FCF4300EC0531 /* MovingStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusViewController.swift; sourceTree = "<group>"; };
 		4ACA5242272FD52D00EC0531 /* BBusTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BBusTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ACA5244272FD52D00EC0531 /* BBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BBusTests.swift; sourceTree = "<group>"; };
+		4ACC26B3274F669800173A32 /* BusSectionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusSectionKeys.swift; sourceTree = "<group>"; };
 		4ADB29B8274B68CE00554A4E /* GetOnAlarmController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOnAlarmController.swift; sourceTree = "<group>"; };
 		4ADB29BA274B6C8300554A4E /* BusPosByVehicleIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusPosByVehicleIdDTO.swift; sourceTree = "<group>"; };
 		4ADB29BC274B6E0B00554A4E /* GetBusPosByVehIdFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBusPosByVehIdFetcher.swift; sourceTree = "<group>"; };
@@ -572,6 +574,7 @@
 			children = (
 				4ACA5212272FCE8500EC0531 /* BusCongestion.swift */,
 				4A094CDE27435C5900428F55 /* BusRemainTime.swift */,
+				4ACC26B3274F669800173A32 /* BusSectionKeys.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -980,6 +983,7 @@
 				049375B7273BE08F0061ACDA /* BusPosByRtidDTO.swift in Sources */,
 				4A992C49273124AF0006FB8C /* FavoriteCollectionViewCell.swift in Sources */,
 				4ADB29C7274B7A7F00554A4E /* GetOnAlarmStatus.swift in Sources */,
+				4ACC26B4274F669800173A32 /* BusSectionKeys.swift in Sources */,
 				4A917DF227462E36002489FE /* EmptyFavoriteNoticeView.swift in Sources */,
 				04AC7D1B2733E7270095CD4E /* AlarmSettingButton.swift in Sources */,
 				4A97C4D4273A822D00F1A765 /* Pushables.swift in Sources */,

--- a/BBus/BBus/Foreground/Station/Model/BusArriveInfos.swift
+++ b/BBus/BBus/Foreground/Station/Model/BusArriveInfos.swift
@@ -1,0 +1,43 @@
+//
+//  BusArriveInfos.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/25.
+//
+
+import Foundation
+
+typealias BusArriveInfo = (firstBusArriveRemainTime: BusRemainTime?, firstBusRelativePosition: String?, firstBusCongestion: BusCongestion?, secondBusArriveRemainTime: BusRemainTime?, secondBusRelativePosition: String?, secondBusCongestion: BusCongestion?, stationOrd: Int, busRouteId: Int, nextStation: String, busNumber: String, routeType: BBusRouteType)
+
+struct BusArriveInfos {
+
+    private var infos: [BusArriveInfo]
+
+    subscript(item: Int) -> BusArriveInfo? {
+        guard 0..<self.infos.count ~= item else { return nil }
+        return self.infos[item]
+    }
+
+    init(infos: [BusArriveInfo] = []) {
+        self.infos = infos
+    }
+
+    static func +(lhs: BusArriveInfos, rhs: BusArriveInfos) -> BusArriveInfos {
+        let newInfos = lhs.infos + rhs.infos
+        return BusArriveInfos(infos: newInfos)
+    }
+
+    func descended() -> BusArriveInfos {
+        let newInfos = self.infos.map { (info) -> BusArriveInfo in
+            var result = info
+            result.firstBusArriveRemainTime?.descend()
+            result.secondBusArriveRemainTime?.descend()
+            return result
+        }
+        return BusArriveInfos(infos: newInfos)
+    }
+
+    func count() -> Int {
+        return self.infos.count
+    }
+}

--- a/BBus/BBus/Foreground/Station/Model/BusSectionKeys.swift
+++ b/BBus/BBus/Foreground/Station/Model/BusSectionKeys.swift
@@ -1,0 +1,30 @@
+//
+//  BusSectionKeys.swift
+//  BBus
+//
+//  Created by 김태훈 on 2021/11/25.
+//
+
+import Foundation
+
+struct BusSectionKeys {
+
+    private var keys: [BBusRouteType]
+
+    subscript(section: Int) -> BBusRouteType? {
+        guard 0..<self.keys.count ~= section else { return nil }
+        return self.keys[section]
+    }
+
+    static func +(lhs: BusSectionKeys, rhs: BusSectionKeys) -> BusSectionKeys {
+        return Self.init(keys: lhs.keys + rhs.keys)
+    }
+
+    init(keys: [BBusRouteType] = []) {
+        self.keys = keys
+    }
+
+    func count() -> Int {
+        return self.keys.count
+    }
+}

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -197,8 +197,8 @@ extension StationViewController: UICollectionViewDelegate {
               let key = viewModel.busKeys[indexPath.section] else { return }
         let busRouteId: Int
 
-        if viewModel.infoBuses.count - 1 >= indexPath.section {
-            busRouteId = viewModel.infoBuses[key]?[indexPath.item].busRouteId ?? 100100048
+        if viewModel.activeBuses.count - 1 >= indexPath.section {
+            busRouteId = viewModel.activeBuses[key]?[indexPath.item]?.busRouteId ?? 100100048
         }
         else {
             busRouteId = viewModel.noInfoBuses[key]?[indexPath.item].busRouteId ?? 100100048
@@ -217,8 +217,8 @@ extension StationViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let viewModel = self.viewModel,
               let key = viewModel.busKeys[section] else { return 0 }
-        if viewModel.infoBuses.count - 1 >= section {
-            return viewModel.infoBuses[key]?.count ?? 0
+        if viewModel.activeBuses.count - 1 >= section {
+            return viewModel.activeBuses[key]?.count() ?? 0
         }
         else {
             return viewModel.noInfoBuses[key]?.count ?? 0
@@ -260,21 +260,19 @@ extension StationViewController: UICollectionViewDataSource {
         }
         
         // InfoBus인 경우: 바인딩
-        // TODO: maxCount 임시 조치, 추후 수정 필요
-        if viewModel.infoBuses.count - 1 >= indexPath.section {
-            self.viewModel?.$infoBuses
+        if viewModel.activeBuses.count - 1 >= indexPath.section {
+            self.viewModel?.$activeBuses
                 .receive(on: DispatchQueue.main)
-                .sink(receiveValue: { [weak self] infoBuses in
+                .sink(receiveValue: { [weak self] activeBuses in
                     guard let key = self?.viewModel?.busKeys[indexPath.section],
-                          let maxCount = infoBuses[key]?.count,
-                          let busInfo = maxCount > indexPath.item ? infoBuses[key]?[indexPath.item] : nil else { return }
+                          let maxCount = activeBuses[key]?.count(),
+                          let busInfo = maxCount > indexPath.item ? activeBuses[key]?[indexPath.item] : nil else { return }
                     configureCell(busInfo)
                 })
                 .store(in: &cell.cancellables)
 
             guard let key = self.viewModel?.busKeys[indexPath.section],
-                  let maxCount = self.viewModel?.infoBuses[key]?.count,
-                  let busInfo = maxCount > indexPath.item ? self.viewModel?.infoBuses[key]?[indexPath.item] : nil  else { return cell }
+                  let busInfo = self.viewModel?.activeBuses[key]?[indexPath.item] else { return cell }
 
             let getOnAlarmViewModel = GetOnAlarmController.shared.viewModel
             let getOffAlarmViewModel = GetOffAlarmController.shared.viewModel
@@ -382,8 +380,8 @@ extension StationViewController: LikeButtonDelegate {
               let station = viewModel.usecase.stationInfo,
               let key = viewModel.busKeys[indexPath.section] else { return nil }
         let item: FavoriteItemDTO
-        if viewModel.infoBuses.count - 1 >= indexPath.section {
-            guard let bus = viewModel.infoBuses[key]?[indexPath.item] else { return nil }
+        if viewModel.activeBuses.count - 1 >= indexPath.section {
+            guard let bus = viewModel.activeBuses[key]?[indexPath.item] else { return nil }
             item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: viewModel.arsId)
         }
         else {
@@ -402,8 +400,8 @@ extension StationViewController: AlarmButtonDelegate {
               let stationID = viewModel.usecase.stationInfo?.stationID,
               let key = viewModel.busKeys[indexPath.section] else { return }
         let bus: BusArriveInfo
-        if viewModel.infoBuses.count - 1 >= indexPath.section {
-            guard let info = viewModel.infoBuses[key]?[indexPath.item] else { return }
+        if viewModel.activeBuses.count - 1 >= indexPath.section {
+            guard let info = viewModel.activeBuses[key]?[indexPath.item] else { return }
             bus = info
         }
         else {

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -193,9 +193,10 @@ final class StationViewController: UIViewController {
 // MARK: - Delegate : CollectionView
 extension StationViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let viewModel = self.viewModel else { return }
+        guard let viewModel = self.viewModel,
+              let key = viewModel.busKeys[indexPath.section] else { return }
         let busRouteId: Int
-        let key = viewModel.busKeys[indexPath.section]
+
         if viewModel.infoBuses.count - 1 >= indexPath.section {
             busRouteId = viewModel.infoBuses[key]?[indexPath.item].busRouteId ?? 100100048
         }
@@ -210,17 +211,16 @@ extension StationViewController: UICollectionViewDelegate {
 extension StationViewController: UICollectionViewDataSource {
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return (self.viewModel?.busKeys.count ?? 0)
+        return (self.viewModel?.busKeys.count() ?? 0)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let viewModel = self.viewModel else { return 0 }
+        guard let viewModel = self.viewModel,
+              let key = viewModel.busKeys[section] else { return 0 }
         if viewModel.infoBuses.count - 1 >= section {
-            let key = viewModel.busKeys[section]
             return viewModel.infoBuses[key]?.count ?? 0
         }
         else {
-            let key = viewModel.busKeys[section]
             return viewModel.noInfoBuses[key]?.count ?? 0
         }
     }
@@ -290,7 +290,7 @@ extension StationViewController: UICollectionViewDataSource {
         }
         // NoInfoBus인 경우: 바로 configure
         else {
-            let key = viewModel.busKeys[indexPath.section]
+            guard let key = viewModel.busKeys[indexPath.section] else { return cell }
             if let busInfo = viewModel.noInfoBuses[key]?[indexPath.item] {
                 configureCell(busInfo)
             }
@@ -304,7 +304,7 @@ extension StationViewController: UICollectionViewDataSource {
                                                                            withReuseIdentifier: SimpleCollectionHeaderView.identifier,
                                                                            for: indexPath) as? SimpleCollectionHeaderView,
               
-                let title = self.viewModel?.busKeys[indexPath.section].toString() else { return UICollectionReusableView() }
+                let title = self.viewModel?.busKeys[indexPath.section]?.toString() else { return UICollectionReusableView() }
         header.configureLayout()
         header.configure(title: title)
         return header
@@ -379,8 +379,8 @@ extension StationViewController: LikeButtonDelegate {
     
     private func makeFavoriteItem(at indexPath: IndexPath) -> FavoriteItemDTO? {
         guard let viewModel = self.viewModel,
-              let station = viewModel.usecase.stationInfo else { return nil }
-        let key = viewModel.busKeys[indexPath.section]
+              let station = viewModel.usecase.stationInfo,
+              let key = viewModel.busKeys[indexPath.section] else { return nil }
         let item: FavoriteItemDTO
         if viewModel.infoBuses.count - 1 >= indexPath.section {
             guard let bus = viewModel.infoBuses[key]?[indexPath.item] else { return nil }
@@ -399,8 +399,8 @@ extension StationViewController: AlarmButtonDelegate {
     func shouldGoToAlarmSettingScene(at cell: UICollectionViewCell) {
         guard let indexPath = self.indexPath(for: cell),
               let viewModel = viewModel,
-              let stationID = viewModel.usecase.stationInfo?.stationID else { return }
-        let key = viewModel.busKeys[indexPath.section]
+              let stationID = viewModel.usecase.stationInfo?.stationID,
+              let key = viewModel.busKeys[indexPath.section] else { return }
         let bus: BusArriveInfo
         if viewModel.infoBuses.count - 1 >= indexPath.section {
             guard let info = viewModel.infoBuses[key]?[indexPath.item] else { return }

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -201,7 +201,7 @@ extension StationViewController: UICollectionViewDelegate {
             busRouteId = viewModel.activeBuses[key]?[indexPath.item]?.busRouteId ?? 100100048
         }
         else {
-            busRouteId = viewModel.noInfoBuses[key]?[indexPath.item].busRouteId ?? 100100048
+            busRouteId = viewModel.inActiveBuses[key]?[indexPath.item]?.busRouteId ?? 100100048
         }
         self.coordinator?.pushToBusRoute(busRouteId: busRouteId)
     }
@@ -221,7 +221,7 @@ extension StationViewController: UICollectionViewDataSource {
             return viewModel.activeBuses[key]?.count() ?? 0
         }
         else {
-            return viewModel.noInfoBuses[key]?.count ?? 0
+            return viewModel.inActiveBuses[key]?.count() ?? 0
         }
     }
     
@@ -265,8 +265,7 @@ extension StationViewController: UICollectionViewDataSource {
                 .receive(on: DispatchQueue.main)
                 .sink(receiveValue: { [weak self] activeBuses in
                     guard let key = self?.viewModel?.busKeys[indexPath.section],
-                          let maxCount = activeBuses[key]?.count(),
-                          let busInfo = maxCount > indexPath.item ? activeBuses[key]?[indexPath.item] : nil else { return }
+                          let busInfo = activeBuses[key]?[indexPath.item] else { return }
                     configureCell(busInfo)
                 })
                 .store(in: &cell.cancellables)
@@ -289,7 +288,7 @@ extension StationViewController: UICollectionViewDataSource {
         // NoInfoBus인 경우: 바로 configure
         else {
             guard let key = viewModel.busKeys[indexPath.section] else { return cell }
-            if let busInfo = viewModel.noInfoBuses[key]?[indexPath.item] {
+            if let busInfo = viewModel.inActiveBuses[key]?[indexPath.item] {
                 configureCell(busInfo)
             }
         }
@@ -385,7 +384,7 @@ extension StationViewController: LikeButtonDelegate {
             item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: viewModel.arsId)
         }
         else {
-            guard let bus = viewModel.noInfoBuses[key]?[indexPath.item] else { return nil }
+            guard let bus = viewModel.inActiveBuses[key]?[indexPath.item] else { return nil }
             item = FavoriteItemDTO(stId: "\(station.stationID)", busRouteId: "\(bus.busRouteId)", ord: "\(bus.stationOrd)", arsId: viewModel.arsId)
         }
         return item
@@ -405,7 +404,7 @@ extension StationViewController: AlarmButtonDelegate {
             bus = info
         }
         else {
-            guard let info = viewModel.noInfoBuses[key]?[indexPath.item] else { return }
+            guard let info = viewModel.inActiveBuses[key]?[indexPath.item] else { return }
             bus = info
         }
         self.coordinator?.pushToAlarmSetting(stationId: stationID,

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -9,16 +9,13 @@ import Foundation
 import Combine
 import UIKit
 
-typealias BusArriveInfo = (firstBusArriveRemainTime: BusRemainTime?, firstBusRelativePosition: String?, firstBusCongestion: BusCongestion?, secondBusArriveRemainTime: BusRemainTime?, secondBusRelativePosition: String?, secondBusCongestion: BusCongestion?, stationOrd: Int, busRouteId: Int, nextStation: String, busNumber: String, routeType: BBusRouteType)
-
-
 final class StationViewModel {
     
     let usecase: StationUsecase
     let arsId: String
     private var cancellables: Set<AnyCancellable>
     @Published private(set) var busKeys: BusSectionKeys
-    @Published private(set) var infoBuses = [BBusRouteType: [BusArriveInfo]]()
+    @Published private(set) var activeBuses = [BBusRouteType: BusArriveInfos]()
     private(set) var noInfoBuses = [BBusRouteType: [BusArriveInfo]]()
     @Published private(set) var favoriteItems = [FavoriteItemDTO]()
     @Published private(set) var nextStation: String? = nil
@@ -47,13 +44,8 @@ final class StationViewModel {
     }
 
     @objc private func descendTime() {
-        self.infoBuses.forEach({ [weak self] in
-            self?.infoBuses[$0.key] = $0.value.map { result in
-                var remainTime = result
-                remainTime.firstBusArriveRemainTime?.descend()
-                remainTime.secondBusArriveRemainTime?.descend()
-                return remainTime
-            }
+        self.activeBuses.forEach({ [weak self] in
+            self?.activeBuses[$0.key] = $0.value.descended()
         })
     }
     
@@ -85,7 +77,7 @@ final class StationViewModel {
     }
 
     private func classifyByRouteType(with buses: [StationByUidItemDTO]) {
-        var infoBuses: [BBusRouteType: [BusArriveInfo]] = [:]
+        var activeBuses: [BBusRouteType: BusArriveInfos] = [:]
         var noInfoBuses: [BBusRouteType: [BusArriveInfo]] = [:]
         buses.forEach() { bus in
             guard let routeType = BBusRouteType(rawValue: Int(bus.routeType) ?? 0) else { return }
@@ -108,8 +100,8 @@ final class StationViewModel {
                 info.secondBusArriveRemainTime = timeAndPositionInfo2.time
                 info.secondBusRelativePosition = timeAndPositionInfo2.position
                 info.secondBusCongestion = timeAndPositionInfo2.time.checkInfo() ? info.firstBusCongestion : nil
-                
-                infoBuses.updateValue((infoBuses[routeType] ?? []) + [info], forKey: routeType)
+
+                activeBuses.updateValue((activeBuses[routeType] ?? BusArriveInfos()) + BusArriveInfos(infos: [info]), forKey: routeType)
             }
             else {
                 info.firstBusArriveRemainTime = nil
@@ -121,10 +113,10 @@ final class StationViewModel {
                 noInfoBuses.updateValue((noInfoBuses[routeType] ?? []) + [info], forKey: routeType)
             }
         }
-        self.infoBuses = infoBuses
+        self.activeBuses = activeBuses
         self.noInfoBuses = noInfoBuses
 
-        let sortedInfoBusesKey = Array(infoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
+        let sortedInfoBusesKey = Array(activeBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
         let sortedNoInfoBusesKey = Array(noInfoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
         self.busKeys = BusSectionKeys(keys: sortedInfoBusesKey) + BusSectionKeys(keys: sortedNoInfoBusesKey)
     }

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -17,7 +17,7 @@ final class StationViewModel {
     let usecase: StationUsecase
     let arsId: String
     private var cancellables: Set<AnyCancellable>
-    @Published private(set) var busKeys: [BBusRouteType]
+    @Published private(set) var busKeys: BusSectionKeys
     @Published private(set) var infoBuses = [BBusRouteType: [BusArriveInfo]]()
     private(set) var noInfoBuses = [BBusRouteType: [BusArriveInfo]]()
     @Published private(set) var favoriteItems = [FavoriteItemDTO]()
@@ -27,7 +27,7 @@ final class StationViewModel {
         self.usecase = usecase
         self.arsId = arsId
         self.cancellables = []
-        self.busKeys = []
+        self.busKeys = BusSectionKeys()
         self.binding()
         self.refresh()
     }
@@ -123,9 +123,10 @@ final class StationViewModel {
         }
         self.infoBuses = infoBuses
         self.noInfoBuses = noInfoBuses
-        
-        let keys = Array(infoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue }) + Array(noInfoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
-        self.busKeys = keys
+
+        let sortedInfoBusesKey = Array(infoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
+        let sortedNoInfoBusesKey = Array(noInfoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
+        self.busKeys = BusSectionKeys(keys: sortedInfoBusesKey) + BusSectionKeys(keys: sortedNoInfoBusesKey)
     }
     
     func add(favoriteItem: FavoriteItemDTO) {

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -16,7 +16,7 @@ final class StationViewModel {
     private var cancellables: Set<AnyCancellable>
     @Published private(set) var busKeys: BusSectionKeys
     @Published private(set) var activeBuses = [BBusRouteType: BusArriveInfos]()
-    private(set) var noInfoBuses = [BBusRouteType: [BusArriveInfo]]()
+    private(set) var inActiveBuses = [BBusRouteType: BusArriveInfos]()
     @Published private(set) var favoriteItems = [FavoriteItemDTO]()
     @Published private(set) var nextStation: String? = nil
     
@@ -78,7 +78,7 @@ final class StationViewModel {
 
     private func classifyByRouteType(with buses: [StationByUidItemDTO]) {
         var activeBuses: [BBusRouteType: BusArriveInfos] = [:]
-        var noInfoBuses: [BBusRouteType: [BusArriveInfo]] = [:]
+        var inActiveBuses: [BBusRouteType: BusArriveInfos] = [:]
         buses.forEach() { bus in
             guard let routeType = BBusRouteType(rawValue: Int(bus.routeType) ?? 0) else { return }
             
@@ -110,14 +110,14 @@ final class StationViewModel {
                 info.secondBusRelativePosition = nil
                 info.secondBusCongestion = nil
                 
-                noInfoBuses.updateValue((noInfoBuses[routeType] ?? []) + [info], forKey: routeType)
+                inActiveBuses.updateValue((inActiveBuses[routeType] ?? BusArriveInfos()) + BusArriveInfos(infos: [info]), forKey: routeType)
             }
         }
         self.activeBuses = activeBuses
-        self.noInfoBuses = noInfoBuses
+        self.inActiveBuses = inActiveBuses
 
         let sortedInfoBusesKey = Array(activeBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
-        let sortedNoInfoBusesKey = Array(noInfoBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
+        let sortedNoInfoBusesKey = Array(inActiveBuses.keys).sorted(by: { $0.rawValue < $1.rawValue })
         self.busKeys = BusSectionKeys(keys: sortedInfoBusesKey) + BusSectionKeys(keys: sortedNoInfoBusesKey)
     }
     


### PR DESCRIPTION
## 작업 내용
- [x] infoBuses 추상화
- [x] noInfoBuses 추상화
- [x] busKeys 추상화

## 근거
[일급 컬렉션](https://velog.io/@tigger/%EC%9D%BC%EA%B8%89-%EC%BB%AC%EB%A0%89%EC%85%98)
[일급 컬렉션 (First Class Collection)의 소개와 써야할 이유](https://jojoldu.tistory.com/412)

## 시연 방법
리팩토링이므로 실행 방식과 동일하다

## 기타 (고민과 해결, 리뷰 포인트 등)
maxCount로 ViewController 에서 갯수 파악하는 로직을 제거
딕셔너리를 따로 감싸지 않은 이유는 딕셔너리는 이미 찾는 값이 없으면 nil을 잘 반환해주기 때문이다.
