### PR TITLE
[데이터 로딩] 16-1. 각 화면에서 네트워크 요청에 대해 response가 오기 전까지 로더를 보여준다

### DIFF
--- a/BBus/BBus/Foreground/AlarmSetting/View/AlarmSettingView.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/View/AlarmSettingView.swift
@@ -25,6 +25,10 @@ final class AlarmSettingView: UIView {
         tableView.contentInset = UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 0)
         return tableView
     }()
+    private lazy var loader: UIActivityIndicatorView = {
+        let loader = UIActivityIndicatorView(style: .large)
+        return loader
+    }()
 
     convenience init() {
         self.init(frame: CGRect())
@@ -35,12 +39,18 @@ final class AlarmSettingView: UIView {
 
     // MARK: - Configure
     private func configureLayout() {
-        self.addSubviews(self.alarmTableView)
+        self.addSubviews(self.alarmTableView, self.loader)
+        
         NSLayoutConstraint.activate([
             self.alarmTableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.alarmTableView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.alarmTableView.topAnchor.constraint(equalTo: self.topAnchor),
             self.alarmTableView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            self.loader.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.loader.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
     }
 
@@ -55,5 +65,15 @@ final class AlarmSettingView: UIView {
     
     func indexPath(for cell: UITableViewCell) -> IndexPath? {
         return self.alarmTableView.indexPath(for: cell)
+    }
+
+    func startLoader() {
+        self.loader.isHidden = false
+        self.loader.startAnimating()
+    }
+
+    func stopLoader() {
+        self.loader.isHidden = true
+        self.loader.stopAnimating()
     }
 }

--- a/BBus/BBus/Foreground/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/ViewModel/AlarmSettingViewModel.swift
@@ -128,4 +128,9 @@ final class AlarmSettingViewModel {
     func sendErrorMessage(_ message: String) {
         self.errorMessage = message
     }
+
+    func isStopLoader() -> Bool {
+        guard let busStationInfos = self.busStationInfos else { return false }
+        return !self.busArriveInfos.arriveInfos.isEmpty && !busStationInfos.isEmpty
+    }
 }

--- a/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
@@ -55,9 +55,9 @@ final class BusRouteViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.busRouteView.startLoader()
         self.viewModel?.configureObserver()
         self.viewModel?.refreshBusPos()
-        self.busRouteView.startLoader()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/BBus/BBus/Foreground/BusRoute/View/BusRouteView.swift
+++ b/BBus/BBus/Foreground/BusRoute/View/BusRouteView.swift
@@ -27,6 +27,10 @@ final class BusRouteView: UIView {
         tableView.separatorColor = BBusColor.bbusLightGray
         return tableView
     }()
+    private lazy var loader: UIActivityIndicatorView = {
+        let loader = UIActivityIndicatorView(style: .large)
+        return loader
+    }()
     private var busRouteTableViewHeightConstraint: NSLayoutConstraint?
     private var tableViewMinHeight: CGFloat {
         return max(self.frame.height - BusRouteHeaderView.headerHeight, 0)
@@ -43,7 +47,7 @@ final class BusRouteView: UIView {
     private func configureLayout() {
         let colorBackgroundViewHeightMultiplier: CGFloat = 0.5
         
-        self.addSubviews(self.colorBackgroundView, self.busRouteScrollView)
+        self.addSubviews(self.colorBackgroundView, self.busRouteScrollView, self.loader)
         
         NSLayoutConstraint.activate([
             self.colorBackgroundView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: colorBackgroundViewHeightMultiplier),
@@ -84,6 +88,11 @@ final class BusRouteView: UIView {
             self.busRouteScrollContentsView.trailingAnchor.constraint(equalTo: self.busRouteScrollView.contentLayoutGuide.trailingAnchor),
             self.busRouteScrollContentsView.bottomAnchor.constraint(equalTo: self.busRouteScrollView.contentLayoutGuide.bottomAnchor),
             self.busRouteScrollContentsView.widthAnchor.constraint(equalTo: self.busRouteScrollView.frameLayoutGuide.widthAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            self.loader.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.loader.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
     }
 
@@ -133,5 +142,15 @@ final class BusRouteView: UIView {
 
     func reload() {
         self.busRouteTableView.reloadData()
+    }
+
+    func startLoader() {
+        self.loader.isHidden = false
+        self.loader.startAnimating()
+    }
+
+    func stopLoader() {
+        self.loader.isHidden = true
+        self.loader.stopAnimating()
     }
 }

--- a/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -120,4 +120,8 @@ final class BusRouteViewModel {
     @objc func refreshBusPos() {
         self.usecase.fetchBusPosList(busRouteId: self.busRouteId)
     }
+
+    func isStopLoader() -> Bool {
+        return self.header != nil && !self.bodys.isEmpty && !self.buses.isEmpty
+    }
 }

--- a/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
+++ b/BBus/BBus/Foreground/BusRoute/ViewModel/BusRouteViewModel.swift
@@ -18,13 +18,18 @@ final class BusRouteViewModel {
     private var cancellables: Set<AnyCancellable>
     private let busRouteId: Int
     @Published var header: BusRouteDTO?
-    @Published var bodys: [BusStationInfo] = []
-    @Published var buses: [BusPosInfo] = []
+    @Published var bodys: [BusStationInfo]
+    @Published var buses: [BusPosInfo]
+    @Published private(set) var stopLoader: Bool = false
 
     init(usecase: BusRouteUsecase, busRouteId: Int) {
         self.usecase = usecase
         self.busRouteId = busRouteId
+        self.header = nil
         self.cancellables = []
+        self.bodys = []
+        self.buses = []
+        self.bindLoader()
         self.bindHeaderInfo()
         self.bindBodysInfo()
         self.bindBusesPosInfo()
@@ -123,5 +128,16 @@ final class BusRouteViewModel {
 
     func isStopLoader() -> Bool {
         return self.header != nil && !self.bodys.isEmpty && !self.buses.isEmpty
+    }
+
+    private func bindLoader() {
+        self.$header.zip(self.$bodys, self.$buses)
+            .dropFirst()
+            .dropFirst()
+            .sink(receiveValue: { result in
+                dump(result)
+                self.stopLoader = true
+            })
+            .store(in: &self.cancellables)
     }
 }

--- a/BBus/BBus/Foreground/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Foreground/Home/View/FavoriteCollectionViewCell.swift
@@ -22,6 +22,10 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
 
         }
     }
+    private lazy var loader: UIActivityIndicatorView = {
+        let loader = UIActivityIndicatorView(style: .large)
+        return loader
+    }()
     class var height: CGFloat { return 70 }
     static let identifier = "FavoriteCollectionViewCell"
     var busNumberYAxisMargin: CGFloat { return 0 }
@@ -42,6 +46,8 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
         
         self.cancellables.forEach { $0.cancel() }
         self.cancellables.removeAll()
+        self.loader.isHidden = false
+        self.loader.startAnimating()
         self.busNumberLabel.text = ""
         self.trailingView.configure(firstBusTime: nil,
                                     firstBusRemaining: nil,
@@ -72,7 +78,8 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
      func configureLayout() {
         let half: CGFloat = 0.5
          
-        self.addSubviews(self.busNumberLabel, self.trailingView)
+         self.addSubviews(self.busNumberLabel, self.trailingView, self.loader)
+
          
         let busNumberLeadingConstraint = self.busNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.busNumberLeadingInterval)
         busNumberLeadingConstraint.priority = UILayoutPriority.defaultHigh
@@ -87,6 +94,13 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
             self.trailingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.trailingView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: half)
         ])
+
+         NSLayoutConstraint.activate([
+            self.loader.topAnchor.constraint(equalTo: self.topAnchor),
+            self.loader.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.loader.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.loader.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: half)
+         ])
     }
 
     func configureDelegate(_ delegate: AlarmButtonDelegate) {
@@ -100,6 +114,8 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
     func configure(busNumber: String, routeType: RouteType?, firstBusTime: String?, firstBusRelativePosition: String?, firstBusCongestion: String?, secondBusTime: String?, secondBusRelativePosition: String?, secondBusCongestion: String?) {
         self.busNumberLabel.text = busNumber
 
+        self.loader.isHidden = true
+        self.loader.stopAnimating()
         switch routeType {
         case .mainLine:
             self.busNumberLabel.textColor = BBusColor.bbusTypeBlue

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -52,6 +52,7 @@ final class MovingStatusViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.movingStatusView.startLoader()
         self.binding()
         self.configureLayout()
         self.configureDelegate()
@@ -137,6 +138,7 @@ final class MovingStatusViewController: UIViewController {
     }
 
     private func binding() {
+        self.bindLoader()
         self.bindHeaderBusInfo()
         self.bindRemainTime()
         self.bindCurrentStation()
@@ -210,6 +212,17 @@ final class MovingStatusViewController: UIViewController {
             .sink(receiveValue: { [weak self] isTerminated in
                 if isTerminated {
                     self?.terminateAlert()
+                }
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func bindLoader() {
+        self.viewModel?.$stopLoader
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] isStop in
+                if isStop {
+                    self?.movingStatusView.stopLoader()
                 }
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/Foreground/MovingStatus/View/MovingStatusView.swift
+++ b/BBus/BBus/Foreground/MovingStatus/View/MovingStatusView.swift
@@ -127,6 +127,10 @@ final class MovingStatusView: UIView {
                                               right: 0)
         return button
     }()
+    private lazy var loader: UIActivityIndicatorView = {
+        let loader = UIActivityIndicatorView(style: .large)
+        return loader
+    }()
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -148,7 +152,7 @@ final class MovingStatusView: UIView {
 
     // MARK: - Configure
     private func configureLayout() {
-        self.addSubviews(self.bottomIndicatorButton, self.endAlarmButton, self.stationsTableView, self.headerView)
+        self.addSubviews(self.bottomIndicatorButton, self.endAlarmButton, self.stationsTableView, self.headerView, self.loader)
         
         NSLayoutConstraint.activate([
             self.bottomIndicatorButton.topAnchor.constraint(equalTo: self.topAnchor),
@@ -254,6 +258,11 @@ final class MovingStatusView: UIView {
             self.stationsTableView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.stationsTableView.leadingAnchor.constraint(equalTo: self.leadingAnchor)
         ])
+
+        NSLayoutConstraint.activate([
+            self.loader.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.loader.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
     }
     
     func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource & BottomIndicatorButtonDelegate & FoldButtonDelegate & EndAlarmButtonDelegate) {
@@ -314,5 +323,15 @@ final class MovingStatusView: UIView {
 
     func reload() {
         self.stationsTableView.reloadData()
+    }
+
+    func startLoader() {
+        self.loader.isHidden = false
+        self.loader.startAnimating()
+    }
+
+    func stopLoader() {
+        self.loader.isHidden = true
+        self.loader.stopAnimating()
     }
 }

--- a/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
+++ b/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
@@ -32,6 +32,7 @@ final class MovingStatusViewModel {
     @Published private(set) var remainingStation: Int? // 6
     @Published private(set) var boardedBus: BoardedBus? // 8
     @Published private(set) var message: String?
+    @Published private(set) var stopLoader: Bool = false
 
     init(usecase: MovingStatusUsecase, busRouteId: Int, fromArsId: String, toArsId: String) {
         self.usecase = usecase
@@ -40,9 +41,7 @@ final class MovingStatusViewModel {
         self.toArsId = toArsId
         self.message = nil
         self.cancellables = []
-        self.bindHeaderInfo()
-        self.bindStationsInfo()
-        self.bindBusesPosInfo()
+        self.binding()
         self.configureObserver()
     }
     
@@ -53,6 +52,13 @@ final class MovingStatusViewModel {
                 self.updateAPI()
             }
         }
+    }
+
+    private func binding() {
+        self.bindLoader()
+        self.bindHeaderInfo()
+        self.bindStationsInfo()
+        self.bindBusesPosInfo()
     }
 
     private func bindHeaderInfo() {
@@ -242,5 +248,13 @@ final class MovingStatusViewModel {
 
     func unfold() {
         self.isFolded = false
+    }
+
+    private func bindLoader() {
+        self.$busInfo.zip(self.$stationInfos).dropFirst()
+            .sink(receiveValue: { _ in
+                self.stopLoader = true
+            })
+            .store(in: &self.cancellables)
     }
 }

--- a/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
+++ b/BBus/BBus/Foreground/MovingStatus/ViewModel/MovingStatusViewModel.swift
@@ -251,7 +251,8 @@ final class MovingStatusViewModel {
     }
 
     private func bindLoader() {
-        self.$busInfo.zip(self.$stationInfos).dropFirst()
+        self.$busInfo.zip(self.$stationInfos)
+            .dropFirst()
             .sink(receiveValue: { _ in
                 self.stopLoader = true
             })

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -69,6 +69,7 @@ final class StationViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.stationView.startLoader()
         self.viewModel?.configureObserver()
         self.viewModel?.refresh()
     }
@@ -145,7 +146,13 @@ final class StationViewController: UIViewController {
         self.viewModel?.$busKeys
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
+                guard let viewModel = self?.viewModel else { return }
+
                 self?.stationView.reload()
+
+                if viewModel.stopLoader {
+                    self?.stationView.stopLoader()
+                }
             })
             .store(in: &self.cancellables)
         
@@ -163,6 +170,15 @@ final class StationViewController: UIViewController {
             .sink(receiveValue: { [weak self] error in
                 guard let _ = error else { return }
                 self?.networkAlert()
+            })
+            .store(in: &self.cancellables)
+
+        self.viewModel?.$stopLoader
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] isStop in
+                if isStop {
+                    self?.stationView.stopLoader()
+                }
             })
             .store(in: &self.cancellables)
     }

--- a/BBus/BBus/Foreground/Station/View/StationView.swift
+++ b/BBus/BBus/Foreground/Station/View/StationView.swift
@@ -30,6 +30,10 @@ final class StationView: UIView {
         collectionView.backgroundColor = BBusColor.bbusLightGray
         return collectionView
     }()
+    private lazy var loader: UIActivityIndicatorView = {
+        let loader = UIActivityIndicatorView(style: .large)
+        return loader
+    }()
 
     convenience init() {
         self.init(frame: CGRect())
@@ -41,7 +45,7 @@ final class StationView: UIView {
     private func configureLayout() {
         let half: CGFloat = 0.5
         
-        self.addSubviews(self.colorBackgroundView, self.stationScrollView)
+        self.addSubviews(self.colorBackgroundView, self.stationScrollView, self.loader)
 
         NSLayoutConstraint.activate([
             self.colorBackgroundView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: half),
@@ -79,6 +83,11 @@ final class StationView: UIView {
             self.stationScrollContentsView.bottomAnchor.constraint(equalTo: self.stationScrollView.contentLayoutGuide.bottomAnchor),
             self.stationScrollContentsView.widthAnchor.constraint(equalTo: self.stationScrollView.frameLayoutGuide.widthAnchor),
             self.stationScrollContentsView.heightAnchor.constraint(equalTo: self.stationBodyCollectionView.heightAnchor, constant: StationHeaderView.headerHeight)
+        ])
+
+        NSLayoutConstraint.activate([
+            self.loader.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.loader.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
     }
 
@@ -118,5 +127,15 @@ final class StationView: UIView {
     
     func indexPath(for cell: UICollectionViewCell) -> IndexPath? {
         return self.stationBodyCollectionView.indexPath(for: cell)
+    }
+
+    func startLoader() {
+        self.loader.isHidden = false
+        self.loader.startAnimating()
+    }
+
+    func stopLoader() {
+        self.loader.isHidden = true
+        self.loader.stopAnimating()
     }
 }

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -142,7 +142,6 @@ final class StationViewModel {
         self.$busKeys.zip(self.$favoriteItems, self.$nextStation)
             .dropFirst()
             .sink(receiveValue: { result in
-                dump(result)
                 self.stopLoader = true
             })
             .store(in: &self.cancellables)

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -17,11 +17,12 @@ final class StationViewModel {
     let usecase: StationUsecase
     let arsId: String
     private var cancellables: Set<AnyCancellable>
+    private(set) var noInfoBuses = [BBusRouteType: [BusArriveInfo]]()
     @Published private(set) var busKeys: [BBusRouteType]
     @Published private(set) var infoBuses = [BBusRouteType: [BusArriveInfo]]()
-    private(set) var noInfoBuses = [BBusRouteType: [BusArriveInfo]]()
     @Published private(set) var favoriteItems = [FavoriteItemDTO]()
     @Published private(set) var nextStation: String? = nil
+    @Published private(set) var stopLoader: Bool = false
     
     init(usecase: StationUsecase, arsId: String) {
         self.usecase = usecase
@@ -58,6 +59,7 @@ final class StationViewModel {
     }
     
     private func binding() {
+        self.bindLoader()
         self.bindFavoriteItems()
         self.bindBusArriveInfo()
     }
@@ -134,5 +136,14 @@ final class StationViewModel {
     
     func remove(favoriteItem: FavoriteItemDTO) {
         self.usecase.remove(favoriteItem: favoriteItem)
+    }
+
+    private func bindLoader() {
+        self.$busKeys.zip(self.$favoriteItems, self.$nextStation).dropFirst()
+            .sink(receiveValue: { result in
+                dump(result)
+                self.stopLoader = true
+            })
+            .store(in: &self.cancellables)
     }
 }

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -139,7 +139,8 @@ final class StationViewModel {
     }
 
     private func bindLoader() {
-        self.$busKeys.zip(self.$favoriteItems, self.$nextStation).dropFirst()
+        self.$busKeys.zip(self.$favoriteItems, self.$nextStation)
+            .dropFirst()
             .sink(receiveValue: { result in
                 dump(result)
                 self.stopLoader = true


### PR DESCRIPTION
## 작업 내용
- [x] 홈 화면의 각 셀들은 각각의 로더를 가지고 있고, 네트워크 요청이 오기 전까지 로더를 보인다
- [x] 버스 노선도 화면에서 viewWillAppear 에서 로더를 실행하고, 새로고침이 완료되기 전까지 로더를 보인다
- [x] 정거장 화면에서 viewWillAppear 에서 로더를 실행하고, 새로고침이 완료되기 전까지 로더를 보인다
- [x] 알람 설정 화면에서 로더를 가지고 있고, 네트워크 요청이 오기 전까지 로더를 보인다
- [x] 이동 현황 화면에서 로더를 가지고 있고, 네트워크 요청이 오기 전까지 로더를 보인다 

## 시연 방법

<img src="https://user-images.githubusercontent.com/65349445/143405577-6f2a6273-8664-4985-948b-a0d4434bd9f2.gif" width = 500>

- 각 화면에서 정보가 보이기 전까지 로더가 표시된다.
 
## 기타 (고민과 해결, 리뷰 포인트 등)
