### PR TITLE
[커스텀 Cell] prepareForReuse 내의 cancellable cancel() 로직 제거

### DIFF
--- a/BBus/BBus/Foreground/AlarmSetting/View/GetOffTableViewCell.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/View/GetOffTableViewCell.swift
@@ -48,7 +48,6 @@ final class GetOffTableViewCell: BusStationTableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        self.cancellables.forEach { $0.cancel() }
         self.cancellables.removeAll()
 
         self.configure(alarmButtonActive: false)

--- a/BBus/BBus/Foreground/AlarmSetting/View/GetOnStatusCell.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/View/GetOnStatusCell.swift
@@ -162,7 +162,6 @@ final class GetOnStatusCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.cancellables.forEach { $0.cancel() }
         self.cancellables.removeAll()
         self.configure(order: "",
                        remainingTime: nil,

--- a/BBus/BBus/Foreground/Home/View/FavoriteCollectionViewCell.swift
+++ b/BBus/BBus/Foreground/Home/View/FavoriteCollectionViewCell.swift
@@ -40,7 +40,6 @@ class FavoriteCollectionViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.cancellables.forEach { $0.cancel() }
         self.cancellables.removeAll()
         self.busNumberLabel.text = ""
         self.trailingView.configure(firstBusTime: nil,


### PR DESCRIPTION
## 개요
* cancellables.removeAll() 을 하게되면 각각의 cancellable들의 deinit이 호출되고, 자동으로 .cancel() 이 실행된다고 한다.

## 레퍼런스
[지수님의 PR Comment](https://github.com/boostcampwm-2021/iOS09-BBus/pull/273#discussion_r756572259)
