### PR TITLE
[리팩토링] Station 화면 UseCase 리팩토링

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		4ACA520B272FCE5F00EC0531 /* BusRouteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA520A272FCE5F00EC0531 /* BusRouteViewModel.swift */; };
 		4ACA520D272FCE6500EC0531 /* BusRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA520C272FCE6500EC0531 /* BusRouteView.swift */; };
 		4ACA5213272FCE8500EC0531 /* BusCongestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5212272FCE8500EC0531 /* BusCongestion.swift */; };
-		4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5214272FCE8A00EC0531 /* StationUseCase.swift */; };
+		4ACA5215272FCE8A00EC0531 /* StationAPIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5214272FCE8A00EC0531 /* StationAPIUseCase.swift */; };
 		4ACA5217272FCE8E00EC0531 /* StationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5216272FCE8E00EC0531 /* StationViewModel.swift */; };
 		4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA5218272FCE9500EC0531 /* StationView.swift */; };
 		4ACA521F272FCEAA00EC0531 /* AlarmSettingBusArriveInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA521E272FCEAA00EC0531 /* AlarmSettingBusArriveInfo.swift */; };
@@ -214,7 +214,7 @@
 		4ACA520A272FCE5F00EC0531 /* BusRouteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteViewModel.swift; sourceTree = "<group>"; };
 		4ACA520C272FCE6500EC0531 /* BusRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteView.swift; sourceTree = "<group>"; };
 		4ACA5212272FCE8500EC0531 /* BusCongestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusCongestion.swift; sourceTree = "<group>"; };
-		4ACA5214272FCE8A00EC0531 /* StationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationUseCase.swift; sourceTree = "<group>"; };
+		4ACA5214272FCE8A00EC0531 /* StationAPIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationAPIUseCase.swift; sourceTree = "<group>"; };
 		4ACA5216272FCE8E00EC0531 /* StationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationViewModel.swift; sourceTree = "<group>"; };
 		4ACA5218272FCE9500EC0531 /* StationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationView.swift; sourceTree = "<group>"; };
 		4ACA521E272FCEAA00EC0531 /* AlarmSettingBusArriveInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingBusArriveInfo.swift; sourceTree = "<group>"; };
@@ -583,7 +583,7 @@
 		4ACA5210272FCE6E00EC0531 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
-				4ACA5214272FCE8A00EC0531 /* StationUseCase.swift */,
+				4ACA5214272FCE8A00EC0531 /* StationAPIUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -1012,7 +1012,7 @@
 				049375BD273C2E120061ACDA /* ArrInfoByRouteDTO.swift in Sources */,
 				873D639A27303B0500E79069 /* HomeCoordinator.swift in Sources */,
 				04045B7F2740F6B30056A433 /* SearchResults.swift in Sources */,
-				4ACA5215272FCE8A00EC0531 /* StationUseCase.swift in Sources */,
+				4ACA5215272FCE8A00EC0531 /* StationAPIUseCase.swift in Sources */,
 				4ACA5213272FCE8500EC0531 /* BusCongestion.swift in Sources */,
 				04AC7D112733AF090095CD4E /* BusRouteTableViewCell.swift in Sources */,
 				04045B812740F6DC0056A433 /* BusSearchResult.swift in Sources */,

--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		04AC7D1B2733E7270095CD4E /* AlarmSettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AC7D1A2733E7270095CD4E /* AlarmSettingButton.swift */; };
 		04C6D6692734B18A00D41678 /* MovingStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6D6682734B18A00D41678 /* MovingStatusTableViewCell.swift */; };
 		04C6D66B2734BCAB00D41678 /* MovingStatusBusTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6D66A2734BCAB00D41678 /* MovingStatusBusTagView.swift */; };
+		04DC47FB27552FE5003380D9 /* StationCalculateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DC47FA27552FE5003380D9 /* StationCalculateUseCase.swift */; };
 		4A04682427327876008D87CE /* BusRouteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682327327876008D87CE /* BusRouteCoordinator.swift */; };
 		4A04682627327BA0008D87CE /* AlarmSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */; };
 		4A04682A2732B7B3008D87CE /* SearchNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0468292732B7B3008D87CE /* SearchNavigationView.swift */; };
@@ -167,6 +168,7 @@
 		04AC7D1A2733E7270095CD4E /* AlarmSettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingButton.swift; sourceTree = "<group>"; };
 		04C6D6682734B18A00D41678 /* MovingStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusTableViewCell.swift; sourceTree = "<group>"; };
 		04C6D66A2734BCAB00D41678 /* MovingStatusBusTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingStatusBusTagView.swift; sourceTree = "<group>"; };
+		04DC47FA27552FE5003380D9 /* StationCalculateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationCalculateUseCase.swift; sourceTree = "<group>"; };
 		4A04682327327876008D87CE /* BusRouteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusRouteCoordinator.swift; sourceTree = "<group>"; };
 		4A04682527327BA0008D87CE /* AlarmSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingCoordinator.swift; sourceTree = "<group>"; };
 		4A0468292732B7B3008D87CE /* SearchNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNavigationView.swift; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				4ACA5214272FCE8A00EC0531 /* StationAPIUseCase.swift */,
+				04DC47FA27552FE5003380D9 /* StationCalculateUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -1030,6 +1033,7 @@
 				4ACA5219272FCE9500EC0531 /* StationView.swift in Sources */,
 				4A1A22E12732CE7900476861 /* SearchResultCollectionViewCell.swift in Sources */,
 				87EB52AE2733A6C6000D5492 /* GetOnStatusCell.swift in Sources */,
+				04DC47FB27552FE5003380D9 /* StationCalculateUseCase.swift in Sources */,
 				4A06AEE92743DAB20027222D /* NotificationNameExtension.swift in Sources */,
 				4ADB29BB274B6C8300554A4E /* BusPosByVehicleIdDTO.swift in Sources */,
 				4ACC26B8274F6BD300173A32 /* BusArriveInfos.swift in Sources */,

--- a/BBus/BBus/Foreground/Station/StationCoordinator.swift
+++ b/BBus/BBus/Foreground/Station/StationCoordinator.swift
@@ -16,7 +16,7 @@ final class StationCoordinator: BusRoutePushable, AlarmSettingPushable {
     }
 
     func start(arsId: String) {
-        let usecase = StationUsecase(usecases: BBusAPIUsecases())
+        let usecase = StationAPIUseCase(usecases: BBusAPIUsecases())
         let viewModel = StationViewModel(usecase: usecase, arsId: arsId)
         let viewController = StationViewController(viewModel: viewModel)
         viewController.coordinator = self

--- a/BBus/BBus/Foreground/Station/StationCoordinator.swift
+++ b/BBus/BBus/Foreground/Station/StationCoordinator.swift
@@ -16,8 +16,11 @@ final class StationCoordinator: BusRoutePushable, AlarmSettingPushable {
     }
 
     func start(arsId: String) {
-        let usecase = StationAPIUseCase(usecases: BBusAPIUsecases())
-        let viewModel = StationViewModel(usecase: usecase, arsId: arsId)
+        let apiUseCase = StationAPIUseCase(usecases: BBusAPIUsecases())
+        let calculateUseCase = StationCalculateUseCase()
+        let viewModel = StationViewModel(apiUseCase: apiUseCase,
+                                         calculateUseCase: calculateUseCase,
+                                         arsId: arsId)
         let viewController = StationViewController(viewModel: viewModel)
         viewController.coordinator = self
         self.navigationPresenter.pushViewController(viewController, animated: true)

--- a/BBus/BBus/Foreground/Station/StationViewController.swift
+++ b/BBus/BBus/Foreground/Station/StationViewController.swift
@@ -184,7 +184,7 @@ final class StationViewController: UIViewController {
     
     private func noInfoAlert() {
         let controller = UIAlertController(title: "정거장 에러",
-                                           message: "죄송합니다. 현재 정보가 제공되지 않는 정거장입니다.",
+                                           message: "서울 외 지역은 정거장 정보를 제공하지 않습니다. 죄송합니다",
                                            preferredStyle: .alert)
         let action = UIAlertAction(title: "확인",
                                    style: .default,

--- a/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
+++ b/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  StationUseCase.swift
+//  StationAPIUseCase.swift
 //  BBus
 //
 //  Created by 김태훈 on 2021/11/01.
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-final class StationUsecase {
+final class StationAPIUseCase {
     typealias StationUsecases = GetStationByUidItemUsecase & GetStationListUsecase & CreateFavoriteItemUsecase & DeleteFavoriteItemUsecase & GetFavoriteItemListUsecase & GetRouteListUsecase
     
     private let usecases: StationUsecases

--- a/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
+++ b/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 protocol StationAPIUsable: BaseUseCase {
-    func loadStationInfo(with arsId: String) -> AnyPublisher<StationDTO?, Error>
+    func loadStationList() -> AnyPublisher<[StationDTO], Error>
     func refreshInfo(about arsId: String) -> AnyPublisher<[StationByUidItemDTO], Error>
     func add(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error>
     func remove(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error>
@@ -28,18 +28,10 @@ final class StationAPIUseCase: StationAPIUsable {
         self.cancellables = []
     }
     
-    func loadStationInfo(with arsId: String) -> AnyPublisher<StationDTO?, Error> {
+    func loadStationList() -> AnyPublisher<[StationDTO], Error> {
         self.usecases.getStationList()
             .decode(type: [StationDTO].self, decoder: JSONDecoder())
-            .tryMap({ [weak self] stations in
-                return self?.findStation(in: stations, with: arsId)
-            })
             .eraseToAnyPublisher()
-    }
-    
-    private func findStation(in stations: [StationDTO], with arsId: String) -> StationDTO? {
-        let station = stations.filter() { $0.arsID == arsId }
-        return station.first
     }
     
     func refreshInfo(about arsId: String) -> AnyPublisher<[StationByUidItemDTO], Error> {

--- a/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
+++ b/BBus/BBus/Foreground/Station/UseCase/StationAPIUseCase.swift
@@ -8,39 +8,33 @@
 import Foundation
 import Combine
 
-final class StationAPIUseCase {
+protocol StationAPIUsable: BaseUseCase {
+    func loadStationInfo(with arsId: String) -> AnyPublisher<StationDTO?, Error>
+    func refreshInfo(about arsId: String) -> AnyPublisher<[StationByUidItemDTO], Error>
+    func add(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error>
+    func remove(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error>
+    func getFavoriteItems() -> AnyPublisher<[FavoriteItemDTO], Error>
+    func loadRoute() -> AnyPublisher<[BusRouteDTO], Error>
+}
+
+final class StationAPIUseCase: StationAPIUsable {
     typealias StationUsecases = GetStationByUidItemUsecase & GetStationListUsecase & CreateFavoriteItemUsecase & DeleteFavoriteItemUsecase & GetFavoriteItemListUsecase & GetRouteListUsecase
     
     private let usecases: StationUsecases
-    @Published private(set) var busRouteList: [BusRouteDTO]
-    @Published private(set) var busArriveInfo: [StationByUidItemDTO]
-    @Published private(set) var stationInfo: StationDTO?
-    @Published private(set) var favoriteItems: [FavoriteItemDTO] // need more
-    @Published private(set) var networkError: Error?
     private var cancellables: Set<AnyCancellable>
     
     init(usecases: StationUsecases) {
         self.usecases = usecases
-        self.busRouteList = []
-        self.busArriveInfo = []
-        self.stationInfo = nil
         self.cancellables = []
-        self.favoriteItems = []
-        self.networkError = nil
     }
     
-    func stationInfoWillLoad(with arsId: String) {
+    func loadStationInfo(with arsId: String) -> AnyPublisher<StationDTO?, Error> {
         self.usecases.getStationList()
             .decode(type: [StationDTO].self, decoder: JSONDecoder())
             .tryMap({ [weak self] stations in
                 return self?.findStation(in: stations, with: arsId)
             })
-            .retry({ [weak self] in
-                self?.stationInfoWillLoad(with: arsId)
-            }, handler: { [weak self] error in
-                self?.networkError = error
-            })
-            .assign(to: &self.$stationInfo)
+            .eraseToAnyPublisher()
     }
     
     private func findStation(in stations: [StationDTO], with arsId: String) -> StationDTO? {
@@ -48,68 +42,34 @@ final class StationAPIUseCase {
         return station.first
     }
     
-    func refreshInfo(about arsId: String) {
-        self.usecases.getStationByUidItem(arsId: arsId)
+    func refreshInfo(about arsId: String) -> AnyPublisher<[StationByUidItemDTO], Error> {
+        return self.usecases.getStationByUidItem(arsId: arsId)
             .decode(type: StationByUidItemResult.self, decoder: JSONDecoder())
             .tryMap({ item in
                 item.msgBody.itemList
             })
-            .retry({ [weak self] in
-                self?.refreshInfo(about: arsId)
-            }, handler: { [weak self] error in
-                self?.networkError = error
-            })
-            .combineLatest(self.$busRouteList) { (busRouteList, entireBusRouteList) in
-                busRouteList.filter { busRoute in
-                    entireBusRouteList.contains{ $0.routeID == busRoute.busRouteId }
-                }
-            }
-            .assign(to: &self.$busArriveInfo)
+            .eraseToAnyPublisher()
     }
     
-    func add(favoriteItem: FavoriteItemDTO) {
-        self.usecases.createFavoriteItem(param: favoriteItem)
-            .retry({ [weak self] in
-                self?.add(favoriteItem: favoriteItem)
-            }, handler: { [weak self] error in
-                self?.networkError = error
-            })
-            .sink(receiveValue: { [weak self] _ in
-                self?.getFavoriteItems()
-            })
-            .store(in: &self.cancellables)
+    func add(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error> {
+        return self.usecases.createFavoriteItem(param: favoriteItem)
+            .eraseToAnyPublisher()
     }
     
-    func remove(favoriteItem: FavoriteItemDTO) {
-        self.usecases.deleteFavoriteItem(param: favoriteItem)
-            .retry({ [weak self] in
-                self?.remove(favoriteItem: favoriteItem)
-            }, handler: { [weak self] error in
-                self?.networkError = error
-            })
-            .sink(receiveValue: { [weak self] _ in
-                self?.getFavoriteItems()
-            })
-            .store(in: &self.cancellables)
+    func remove(favoriteItem: FavoriteItemDTO) -> AnyPublisher<Data, Error> {
+        return self.usecases.deleteFavoriteItem(param: favoriteItem)
+            .eraseToAnyPublisher()
     }
     
-    func getFavoriteItems() {
-        self.usecases.getFavoriteItemList()
+    func getFavoriteItems() -> AnyPublisher<[FavoriteItemDTO], Error> {
+        return self.usecases.getFavoriteItemList()
             .decode(type: [FavoriteItemDTO].self, decoder: PropertyListDecoder())
-            .catchError({ [weak self] error in
-                self?.networkError = error
-            })
-            .assign(to: &self.$favoriteItems)
+            .eraseToAnyPublisher()
     }
     
-    func loadRoute() {
-        self.usecases.getRouteList()
+    func loadRoute() -> AnyPublisher<[BusRouteDTO], Error> {
+        return self.usecases.getRouteList()
             .decode(type: [BusRouteDTO].self, decoder: JSONDecoder())
-            .retry({ [weak self] in
-                self?.loadRoute()
-            }, handler: { [weak self] error in
-                self?.networkError = error
-            })
-            .assign(to: &self.$busRouteList)
+            .eraseToAnyPublisher()
     }
 }

--- a/BBus/BBus/Foreground/Station/UseCase/StationCalculateUseCase.swift
+++ b/BBus/BBus/Foreground/Station/UseCase/StationCalculateUseCase.swift
@@ -1,0 +1,19 @@
+//
+//  StationCalculateUseCase.swift
+//  BBus
+//
+//  Created by 최수정 on 2021/11/30.
+//
+
+import Foundation
+
+protocol StationCalculatable: BaseUseCase {
+    func findStation(in stations: [StationDTO], with arsId: String) -> StationDTO?
+}
+
+final class StationCalculateUseCase: StationCalculatable {
+    func findStation(in stations: [StationDTO], with arsId: String) -> StationDTO? {
+        let station = stations.filter() { $0.arsID == arsId }
+        return station.first
+    }
+}

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class StationViewModel {
     
-    let usecase: StationUsecase
+    let usecase: StationAPIUseCase
     let arsId: String
     private var cancellables: Set<AnyCancellable>
     @Published private(set) var busKeys: BusSectionKeys
@@ -21,7 +21,7 @@ final class StationViewModel {
     @Published private(set) var nextStation: String? = nil
     @Published private(set) var stopLoader: Bool = false
     
-    init(usecase: StationUsecase, arsId: String) {
+    init(usecase: StationAPIUseCase, arsId: String) {
         self.usecase = usecase
         self.arsId = arsId
         self.cancellables = []

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -22,8 +22,8 @@ final class StationViewModel {
     @Published private(set) var favoriteItems: [FavoriteItemDTO]?
     @Published private(set) var nextStation: String?
     @Published private(set) var stopLoader: Bool
-    private var cancellables: Set<AnyCancellable>
     @Published private(set) var error: Error?
+    private var cancellables: Set<AnyCancellable>
     
     init(apiUseCase: StationAPIUsable, calculateUseCase: StationCalculatable, arsId: String) {
         self.apiUseCase = apiUseCase

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -36,7 +36,6 @@ final class StationViewModel {
         self.cancellables = []
         self.stopLoader = false
         
-        self.load()
         self.bind()
     }
 
@@ -75,12 +74,14 @@ final class StationViewModel {
         })
     }
     
-    private func load() {
-        self.loadStationInfo(with: self.arsId)
-        self.loadRoute()
+    private func bind() {
+        self.bindStationInfo(with: self.arsId)
+        self.bindBusRouteList()
+        self.bindLoader()
+        self.bindFavoriteItems()
     }
-
-    private func loadStationInfo(with arsId: String) {
+    
+    private func bindStationInfo(with arsId: String) {
         self.apiUseCase.loadStationList()
             .tryMap({ [weak self] stations in
                 return self?.calculateUseCase.findStation(in: stations, with: arsId)
@@ -99,17 +100,12 @@ final class StationViewModel {
             .store(in: &self.cancellables)
     }
     
-    private func loadRoute() {
+    private func bindBusRouteList() {
         self.apiUseCase.loadRoute()
             .catchError({ [weak self] error in
                 self?.error = error
             })
             .assign(to: &self.$busRouteList)
-    }
-    
-    private func bind() {
-        self.bindLoader()
-        self.bindFavoriteItems()
     }
     
     private func bindFavoriteItems() {

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -201,7 +201,7 @@ final class StationViewModel {
 
     private func bindLoader() {
         self.$busKeys.zip(self.$favoriteItems, self.$stationInfo)
-            .first()
+            .output(at: 1)
             .sink(receiveValue: { [weak self] _ in
                 self?.stopLoader = true
             })

--- a/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
+++ b/BBus/BBus/Foreground/Station/ViewModel/StationViewModel.swift
@@ -202,15 +202,15 @@ final class StationViewModel {
     private func bindLoader() {
         self.$busKeys.zip(self.$favoriteItems, self.$stationInfo)
             .first()
-            .sink(receiveValue: { _ in
-                self.stopLoader = true
+            .sink(receiveValue: { [weak self] _ in
+                self?.stopLoader = true
             })
             .store(in: &self.cancellables)
         
         self.$busKeys
             .dropFirst(2)
-            .sink(receiveValue: { result in
-                self.stopLoader = true
+            .sink(receiveValue: { [weak self] result in
+                self?.stopLoader = true
             })
             .store(in: &self.cancellables)
     }

--- a/BBus/BBus/Global/Network/BBusAPIError.swift
+++ b/BBus/BBus/Global/Network/BBusAPIError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum BBusAPIError: Error {
     case systemError, noneParamError, wrongParamError, noneResultError, noneAccessKeyError, noneRegisteredKeyError, suspendedKeyError, exceededKeyError, wrongRequestError, wrongRouteIdError, wrongStationError, noneBusArriveInfoError, wrongStartStationIdError, wrongEndStationIdError, preparingAPIError, wrongFormatError, noMoreAccessKeyError,
-         trafficExceed
+         trafficExceed, invalidStationError
     
     init?(errorCode: Int) {
         switch errorCode {


### PR DESCRIPTION
## 작업 내용
- [x] 각 메소드 리턴타입 Publisher 타입으로 변경
- [x] 로직 담당 / 네트워크 담당 유즈케이스 분리
- [x] 분리한 유즈케이스 프로토콜 선언
- [x] 타 지역 정거장이라 정보 제공안되는 얼럿 띄우는 로직 수정 

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 타 지역 정거장이라 정보 제공 안되는 얼럿을 띄워야 할 때를 헤더 값이 nil일 때로 판단했었는데 이제 error로 판단하도록 변경함.
- nil로 판단하니 초기 값인지 헤더 정보를 받았는데도 nil이 온 것인지 구분이 불가능해서 변경하였음.
- 따라서 viewModel의 networkError를 그냥 error로 이름 변경하고 거기에 저장한 뒤, 뷰컨에서 $error에 바인딩해서 error를 switch case 문으로 구별해서 알맞은 얼럿을 띄우도록 함.
