### PR TITLE
[리팩토링] 홈 화면 Status Bar 접근 로직 리팩토링

### DIFF
--- a/BBus/BBus/Foreground/Home/HomeCoordinator.swift
+++ b/BBus/BBus/Foreground/Home/HomeCoordinator.swift
@@ -15,7 +15,7 @@ final class HomeCoordinator: SearchPushable, BusRoutePushable, AlarmSettingPusha
         self.navigationPresenter = presenter
     }
 
-    func start() {
+    func start(statusBarHeight: CGFloat?) {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
@@ -23,8 +23,9 @@ final class HomeCoordinator: SearchPushable, BusRoutePushable, AlarmSettingPusha
         let apiUseCase = HomeAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = HomeCalculateUseCase()
         let viewModel = HomeViewModel(apiUseCase: apiUseCase, calculateUseCase: calculateUseCase)
-        let viewController = HomeViewController(viewModel: viewModel)
+        let viewController = HomeViewController(viewModel: viewModel, statusBarHegiht: statusBarHeight)
         viewController.coordinator = self
+
         navigationPresenter.pushViewController(viewController, animated: false) // present
     }
 }

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -16,16 +16,19 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
     private let viewModel: HomeViewModel?
 
     private lazy var homeView = HomeView()
-
+    private let statusBarHeight: CGFloat?
+    
     private var cancellables: Set<AnyCancellable> = []
 
-    init(viewModel: HomeViewModel) {
+    init(viewModel: HomeViewModel, statusBarHegiht: CGFloat?) {
         self.viewModel = viewModel
+        self.statusBarHeight = statusBarHegiht
         super.init(nibName: nil, bundle: nil)
     }
 
     required init?(coder: NSCoder) {
         self.viewModel = nil
+        self.statusBarHeight = nil
         super.init(coder: coder)
     }
 
@@ -64,19 +67,18 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
     }
 
     private func configureStatusBarLayout() {
-        let app = UIApplication.shared
-        let statusBarHeight: CGFloat = app.statusBarFrame.size.height
+        if let statusBarHeight = self.statusBarHeight {
+            let statusbarView = UIView()
+            statusbarView.backgroundColor = BBusColor.white //컬러 설정 부분
 
-        let statusbarView = UIView()
-        statusbarView.backgroundColor = BBusColor.white //컬러 설정 부분
-
-        self.view.addSubviews(statusbarView)
-        NSLayoutConstraint.activate([
-            statusbarView.heightAnchor.constraint(equalToConstant: statusBarHeight),
-            statusbarView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1.0),
-            statusbarView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            statusbarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
-        ])
+            self.view.addSubviews(statusbarView)
+            NSLayoutConstraint.activate([
+                statusbarView.heightAnchor.constraint(equalToConstant: statusBarHeight),
+                statusbarView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1.0),
+                statusbarView.topAnchor.constraint(equalTo: self.view.topAnchor),
+                statusbarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+            ])
+        }
         
         self.homeView.configureLayout()
     }

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -56,31 +56,29 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
     // MARK: - Configuration
     func configureLayout() {
         self.view.addSubviews(self.homeView)
-
         NSLayoutConstraint.activate([
             self.homeView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             self.homeView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             self.homeView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
             self.homeView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
         ])
-
+        
+        self.homeView.configureLayout()
     }
 
     private func configureStatusBarLayout() {
-        if let statusBarHeight = self.statusBarHeight {
-            let statusbarView = UIView()
-            statusbarView.backgroundColor = BBusColor.white //컬러 설정 부분
-
-            self.view.addSubviews(statusbarView)
-            NSLayoutConstraint.activate([
-                statusbarView.heightAnchor.constraint(equalToConstant: statusBarHeight),
-                statusbarView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1.0),
-                statusbarView.topAnchor.constraint(equalTo: self.view.topAnchor),
-                statusbarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
-            ])
-        }
+        guard let statusBarHeight = self.statusBarHeight else { return }
         
-        self.homeView.configureLayout()
+        let statusbarView = UIView()
+        statusbarView.backgroundColor = BBusColor.white //컬러 설정 부분
+
+        self.view.addSubviews(statusbarView)
+        NSLayoutConstraint.activate([
+            statusbarView.heightAnchor.constraint(equalToConstant: statusBarHeight),
+            statusbarView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1.0),
+            statusbarView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            statusbarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        ])
     }
     
     func configureDelegate() {

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -14,6 +14,10 @@ final class AppCoordinator: NSObject, Coordinator {
     var navigationPresenter: UINavigationController
     var movingStatusPresenter: UIViewController?
     var childCoordinators: [Coordinator]
+    
+    var statusBarHeight: CGFloat? {
+        return self.navigationWindow.windowScene?.statusBarManager?.statusBarFrame.height
+    }
 
     init(navigationWindow: UIWindow, movingStatusWindow: UIWindow) {
         self.navigationWindow = navigationWindow
@@ -33,7 +37,7 @@ final class AppCoordinator: NSObject, Coordinator {
         coordinator.delegate = self
         coordinator.navigationPresenter = self.navigationPresenter
         self.childCoordinators.append(coordinator)
-        coordinator.start()
+        coordinator.start(statusBarHeight: self.statusBarHeight)
         
         self.navigationWindow.makeKeyAndVisible()
         self.movingStatusWindow.makeKeyAndVisible()
@@ -191,4 +195,3 @@ extension AppCoordinator: CoordinatorFinishDelegate {
         }
     }
 }
-

--- a/BBus/BBus/Global/Coordinator/Coordinator.swift
+++ b/BBus/BBus/Global/Coordinator/Coordinator.swift
@@ -32,12 +32,9 @@ typealias CoordinatorDelegate = (CoordinatorFinishDelegate & CoordinatorCreateDe
 protocol Coordinator: AnyObject {
     var navigationPresenter: UINavigationController { get set }
     var delegate: CoordinatorDelegate? { get set }
-    func start()
 }
 
 extension Coordinator {
-    func start() { }
-
     func coordinatorDidFinish() {
         self.delegate?.removeChildCoordinator(self)
     }


### PR DESCRIPTION
## 작업 내용
- [ ] Status Bar 접근 방식을 deprecated 되지 않은 방법으로 변경

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- UIApplication.shared.statusBar는 iOS 13.0 부터 deprecated 되었음 -> 방식 변경 필요!
- StatusBar에 접근하려면 현재 view가 속한 window에 접근해야함
- window를 가지고 있는 것은 AppCoordinator
- 그리고 Home을 start하는 것도 AppCoordinator
- 따라서 AppCoordinator에서 `HomeCoordinator.start(statusBarHeight: CGFloat?)` 로 전달해주도록 하였음.