### PR TITLE
[리펙토링] BaseViewController 생성

### DIFF
--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingViewController.swift
@@ -8,25 +8,12 @@
 import UIKit
 import Combine
 
-final class AlarmSettingViewController: UIViewController {
-
+final class AlarmSettingViewController: UIViewController, BaseViewControllerType {
+    
     weak var coordinator: AlarmSettingCoordinator?
-    private lazy var alarmSettingView = AlarmSettingView()
-    private lazy var customNavigationBar = CustomNavigationBar()
-    private lazy var refreshButton: ThrottleButton = {
-        let radius: CGFloat = 25
-
-        let button = ThrottleButton()
-        button.setImage(BBusImage.refresh, for: .normal)
-        button.layer.cornerRadius = radius
-        button.tintColor = BBusColor.white
-        button.backgroundColor = BBusColor.darkGray
-        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) { [weak self] in
-            self?.viewModel?.refresh()
-        }
-        return button
-    }()
     private let viewModel: AlarmSettingViewModel?
+    private lazy var alarmSettingView = AlarmSettingView()
+    
     private var cancellables: Set<AnyCancellable> = []
     
     init(viewModel: AlarmSettingViewModel) {
@@ -41,12 +28,9 @@ final class AlarmSettingViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.baseViewDidLoad()
         
         self.configureColor()
-        self.configureLayout()
-        self.configureDelegate()
-        
-        self.binding()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -63,45 +47,26 @@ final class AlarmSettingViewController: UIViewController {
     }
     
     // MARK: - Configure
-    private func configureLayout() {
-        let refreshButtonWidthAnchor: CGFloat = 50
-        let refreshTrailingBottomInterval: CGFloat = -16
-        
-        self.view.addSubviews(self.customNavigationBar, self.alarmSettingView, self.refreshButton)
-
+    func configureLayout() {
+        self.view.addSubviews(self.alarmSettingView)
         NSLayoutConstraint.activate([
-            self.customNavigationBar.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            self.customNavigationBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            self.customNavigationBar.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
-        ])
-
-        NSLayoutConstraint.activate([
-            self.alarmSettingView.topAnchor.constraint(equalTo: self.customNavigationBar.bottomAnchor),
+            self.alarmSettingView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: CustomNavigationBar.height),
             self.alarmSettingView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             self.alarmSettingView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.alarmSettingView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
         ])
-
-        NSLayoutConstraint.activate([
-            self.refreshButton.widthAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.heightAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: refreshTrailingBottomInterval),
-            self.refreshButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: refreshTrailingBottomInterval)
-        ])
     }
 
-    private func configureDelegate() {
+    func configureDelegate() {
         self.alarmSettingView.configureDelegate(self)
-        self.customNavigationBar.configureDelegate(self)
     }
 
     private func configureColor() {
         self.view.backgroundColor = BBusColor.white
-        self.customNavigationBar.configureTintColor(color: BBusColor.black)
-        self.customNavigationBar.configureAlpha(alpha: 1)
+        self.alarmSettingView.configureColor(color: BBusColor.black)
     }
     
-    private func binding() {
+    func bindAll() {
         self.bindBusArriveInfos()
         self.bindBusStationInfos()
         self.bindErrorMessage()
@@ -127,7 +92,7 @@ final class AlarmSettingViewController: UIViewController {
                     self?.alarmSettingView.reload()
                     if let viewModel = self?.viewModel,
                        let stationName = infos.first?.name {
-                        self?.customNavigationBar.configureTitle(busName: viewModel.busName,
+                        self?.alarmSettingView.configureTitle(busName: viewModel.busName,
                                                                  stationName: stationName,
                                                                  routeType: viewModel.routeType)
                     }
@@ -158,6 +123,10 @@ final class AlarmSettingViewController: UIViewController {
                 self?.alarmSettingView.stopLoader()
             })
             .store(in: &self.cancellables)
+    }
+    
+    func refresh() {
+        self.viewModel?.refresh()
     }
     
     private func alarmSettingAlert(message: String) {
@@ -339,6 +308,13 @@ extension AlarmSettingViewController: UITableViewDelegate {
 extension AlarmSettingViewController: BackButtonDelegate {
     func touchedBackButton() {
         self.coordinator?.terminate()
+    }
+}
+
+// MARK: - Delegate: RefreshButton
+extension AlarmSettingViewController: RefreshButtonDelegate {
+    func buttonTapped() {
+        self.refresh()
     }
 }
 

--- a/BBus/BBus/Foreground/AlarmSetting/View/AlarmSettingView.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/View/AlarmSettingView.swift
@@ -11,6 +11,14 @@ final class AlarmSettingView: UIView {
     
     static let tableViewSectionCount = 2
     static let tableViewHeaderHeight: CGFloat = 35
+    
+    private weak var refreshButtonDelegate: RefreshButtonDelegate? {
+        didSet {
+            self.refreshButton.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) { [weak self] in
+                self?.refreshButtonDelegate?.buttonTapped()
+            }
+        }
+    }
 
     private lazy var alarmTableView: UITableView = {
         let tableViewLeftInset: CGFloat = 90
@@ -29,6 +37,17 @@ final class AlarmSettingView: UIView {
         let loader = UIActivityIndicatorView(style: .large)
         return loader
     }()
+    private lazy var refreshButton: ThrottleButton = {
+        let radius: CGFloat = 25
+
+        let button = ThrottleButton()
+        button.setImage(BBusImage.refresh, for: .normal)
+        button.layer.cornerRadius = radius
+        button.tintColor = BBusColor.white
+        button.backgroundColor = BBusColor.darkGray
+        return button
+    }()
+    private lazy var customNavigationBar = CustomNavigationBar()
 
     convenience init() {
         self.init(frame: CGRect())
@@ -54,9 +73,22 @@ final class AlarmSettingView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource) {
+    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource & BackButtonDelegate & RefreshButtonDelegate) {
         self.alarmTableView.delegate = delegate
         self.alarmTableView.dataSource = delegate
+        self.customNavigationBar.configureDelegate(delegate)
+        self.refreshButtonDelegate = delegate
+    }
+    
+    func configureColor(color: UIColor?) {
+        self.customNavigationBar.configureTintColor(color: color)
+        self.customNavigationBar.configureAlpha(alpha: 1)
+    }
+    
+    func configureTitle(busName: String, stationName: String, routeType: RouteType?) {
+        self.customNavigationBar.configureTitle(busName: busName,
+                                                stationName: stationName,
+                                                routeType: routeType)
     }
     
     func reload() {

--- a/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
@@ -9,18 +9,7 @@ import UIKit
 import Combine
 
 final class BusRouteViewController: UIViewController, BaseViewControllerType {
-    func refresh() {
-        self.viewModel?.refreshBusPos()
-    }
     
-    func bindAll() {
-        self.bindLoader()
-        self.bindBusRouteHeaderResult()
-        self.bindBusRouteBodyResult()
-        self.bindBusesPosInfo()
-        self.bindNetworkError()
-    }
-
     weak var coordinator: BusRouteCoordinator?
     private let viewModel: BusRouteViewModel?
     private lazy var busRouteView = BusRouteView()
@@ -72,6 +61,18 @@ final class BusRouteViewController: UIViewController, BaseViewControllerType {
 
     func configureDelegate() {
         self.busRouteView.configureDelegate(self)
+    }
+    
+    func refresh() {
+        self.viewModel?.refreshBusPos()
+    }
+    
+    func bindAll() {
+        self.bindLoader()
+        self.bindBusRouteHeaderResult()
+        self.bindBusRouteBodyResult()
+        self.bindBusesPosInfo()
+        self.bindNetworkError()
     }
 
     private func configureBaseColor() {

--- a/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
+++ b/BBus/BBus/Foreground/BusRoute/BusRouteViewController.swift
@@ -8,30 +8,24 @@
 import UIKit
 import Combine
 
-final class BusRouteViewController: UIViewController {
+final class BusRouteViewController: UIViewController, BaseViewControllerType {
+    func refresh() {
+        self.viewModel?.refreshBusPos()
+    }
+    
+    func bindAll() {
+        self.bindLoader()
+        self.bindBusRouteHeaderResult()
+        self.bindBusRouteBodyResult()
+        self.bindBusesPosInfo()
+        self.bindNetworkError()
+    }
 
     weak var coordinator: BusRouteCoordinator?
-    private lazy var customNavigationBar = CustomNavigationBar()
-    private lazy var busRouteView = BusRouteView()
     private let viewModel: BusRouteViewModel?
+    private lazy var busRouteView = BusRouteView()
+    
     private var cancellables: Set<AnyCancellable> = []
-    private var busTags: [BusTagView] = []
-    private var busIcon: UIImage?
-
-    private lazy var refreshButton: UIButton = {
-        let radius: CGFloat = 25
-
-        let button = UIButton()
-        button.setImage(BBusImage.refresh, for: .normal)
-        button.layer.cornerRadius = radius
-        button.tintColor = BBusColor.white
-        button.backgroundColor = BBusColor.darkGray
-
-        button.addAction(UIAction(handler: { [weak self] _ in
-            self?.viewModel?.refreshBusPos()
-        }), for: .touchUpInside)
-        return button
-    }()
 
     init(viewModel: BusRouteViewModel) {
         self.viewModel = viewModel
@@ -45,31 +39,28 @@ final class BusRouteViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.baseViewDidLoad()
 
         self.busRouteView.startLoader()
-        self.binding()
-        self.configureLayout()
-        self.configureDelegate()
         self.configureBaseColor()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.baseViewWillAppear()
+        
         self.viewModel?.configureObserver()
-        self.viewModel?.refreshBusPos()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        
         self.viewModel?.cancelObserver()
     }
 
     // MARK: - Configure
-    private func configureLayout() {
-        let refreshButtonWidthAnchor: CGFloat = 50
-        let refreshTrailingBottomInterval: CGFloat = -16
-        
-        self.view.addSubviews(self.busRouteView, self.customNavigationBar, self.refreshButton)
+    func configureLayout() {
+        self.view.addSubviews(self.busRouteView)
 
         NSLayoutConstraint.activate([
             self.busRouteView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
@@ -77,87 +68,15 @@ final class BusRouteViewController: UIViewController {
             self.busRouteView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             self.busRouteView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
-
-        NSLayoutConstraint.activate([
-            self.customNavigationBar.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            self.customNavigationBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            self.customNavigationBar.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
-        ])
-
-        self.busRouteView.configureTableViewHeight(count: 20)
-        NSLayoutConstraint.activate([
-            self.refreshButton.widthAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.heightAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: refreshTrailingBottomInterval),
-            self.refreshButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: refreshTrailingBottomInterval)
-        ])
     }
 
-    private func configureDelegate() {
+    func configureDelegate() {
         self.busRouteView.configureDelegate(self)
-        self.customNavigationBar.configureDelegate(self)
     }
 
     private func configureBaseColor() {
         self.view.backgroundColor = BBusColor.gray
-        self.customNavigationBar.configureBackgroundColor(color: BBusColor.gray)
-        self.customNavigationBar.configureTintColor(color: BBusColor.white)
-        self.customNavigationBar.configureAlpha(alpha: 0)
         self.busRouteView.configureColor(to: BBusColor.gray)
-    }
-    
-    private func configureBusColor(type: RouteType) {
-        let color: UIColor?
-
-        switch type {
-        case .mainLine:
-            color = BBusColor.bbusTypeBlue
-            self.busIcon = BBusImage.blueBusIcon
-        case .broadArea:
-            color = BBusColor.bbusTypeRed
-            self.busIcon = BBusImage.redBusIcon
-        case .customized:
-            color = BBusColor.bbusTypeGreen
-            self.busIcon = BBusImage.greenBusIcon
-        case .circulation:
-            color = BBusColor.bbusTypeCirculation
-            self.busIcon = BBusImage.circulationBusIcon
-        case .lateNight:
-            color = BBusColor.bbusTypeBlue
-            self.busIcon = BBusImage.blueBusIcon
-        case .localLine:
-            color = BBusColor.bbusTypeGreen
-            self.busIcon = BBusImage.greenBusIcon
-        }
-
-        self.view.backgroundColor = color
-        self.customNavigationBar.configureBackgroundColor(color: color)
-        self.customNavigationBar.configureTintColor(color: BBusColor.white)
-        self.customNavigationBar.configureAlpha(alpha: 0)
-        self.busRouteView.configureColor(to: color)
-    }
-
-    private func configureBusTags(buses: [BusPosInfo]) {
-        self.busTags.forEach { $0.removeFromSuperview() }
-        self.busTags.removeAll()
-
-        buses.forEach { [weak self] bus in
-            guard let self = self else { return }
-            let tag = self.busRouteView.createBusTag(location: bus.location,
-                                                     busIcon: self.busIcon,
-                                                     busNumber: bus.number,
-                                                     busCongestion: bus.congestion.toString(),
-                                                     isLowFloor: bus.islower)
-            self.busTags.append(tag)
-        }
-    }
-
-    private func binding() {
-        self.bindLoader()
-        self.bindBusRouteHeaderResult()
-        self.bindBusRouteBodyResult()
-        self.bindBusesPosInfo()
-        self.bindNetworkError()
     }
 
     private func bindBusRouteHeaderResult() {
@@ -165,12 +84,12 @@ final class BusRouteViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] header in
                 if let header = header {
-                    self?.customNavigationBar.configureBackButtonTitle(header.busRouteName)
+                    self?.busRouteView.configureBackButtonTitle(title: header.busRouteName)
                     self?.busRouteView.configureHeaderView(busType: header.routeType.rawValue+"버스",
                                                           busNumber: header.busRouteName,
                                                           fromStation: header.startStation,
                                                           toStation: header.endStation)
-                    self?.configureBusColor(type: header.routeType)
+                    self?.view.backgroundColor = self?.busRouteView.configureBusColor(type: header.routeType)
                 }
             })
             .store(in: &self.cancellables)
@@ -192,7 +111,7 @@ final class BusRouteViewController: UIViewController {
             .sink(receiveValue: { [weak self] buses in
                 guard let viewModel = self?.viewModel else { return }
 
-                self?.configureBusTags(buses: buses)
+                self?.busRouteView.configureBusTags(buses: buses)
 
                 if viewModel.stopLoader {
                     self?.busRouteView.stopLoader()
@@ -279,10 +198,10 @@ extension BusRouteViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let baseLineContentOffset = BusRouteHeaderView.headerHeight - CustomNavigationBar.height
         if scrollView.contentOffset.y >= baseLineContentOffset {
-            self.customNavigationBar.configureAlpha(alpha: 1)
+            self.busRouteView.configureNavigationAlpha(alpha: 1)
         }
         else {
-            self.customNavigationBar.configureAlpha(alpha: CGFloat(scrollView.contentOffset.y/baseLineContentOffset))
+            self.busRouteView.configureNavigationAlpha(alpha: CGFloat(scrollView.contentOffset.y/baseLineContentOffset))
         }
     }
 

--- a/BBus/BBus/Foreground/BusRoute/View/BusRouteView.swift
+++ b/BBus/BBus/Foreground/BusRoute/View/BusRouteView.swift
@@ -31,6 +31,23 @@ final class BusRouteView: UIView {
         let loader = UIActivityIndicatorView(style: .large)
         return loader
     }()
+    private lazy var customNavigationBar = CustomNavigationBar()
+    private lazy var refreshButton: UIButton = {
+        let radius: CGFloat = 25
+
+        let button = UIButton()
+        button.setImage(BBusImage.refresh, for: .normal)
+        button.layer.cornerRadius = radius
+        button.tintColor = BBusColor.white
+        button.backgroundColor = BBusColor.darkGray
+
+        button.addAction(UIAction(handler: { [weak self] _ in
+//            self?.viewModel?.refreshBusPos()
+        }), for: .touchUpInside)
+        return button
+    }()
+    private var busTags: [BusTagView] = []
+    private var busIcon: UIImage?
     private var busRouteTableViewHeightConstraint: NSLayoutConstraint?
     private var tableViewMinHeight: CGFloat {
         return max(self.frame.height - BusRouteHeaderView.headerHeight, 0)
@@ -96,15 +113,19 @@ final class BusRouteView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource & UIScrollViewDelegate) {
+    func configureDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource & UIScrollViewDelegate & BackButtonDelegate) {
         self.busRouteTableView.delegate = delegate
         self.busRouteTableView.dataSource = delegate
         self.busRouteScrollView.delegate = delegate
+        self.customNavigationBar.configureDelegate(delegate)
     }
 
     func configureColor(to color: UIColor?) {
         self.colorBackgroundView.backgroundColor = color
         self.busHeaderView.backgroundColor = color
+        self.customNavigationBar.configureBackgroundColor(color: color)
+        self.customNavigationBar.configureTintColor(color: BBusColor.white)
+        self.customNavigationBar.configureAlpha(alpha: 0)
     }
 
     func configureTableViewHeight(count: Int) {
@@ -152,5 +173,56 @@ final class BusRouteView: UIView {
     func stopLoader() {
         self.loader.isHidden = true
         self.loader.stopAnimating()
+    }
+    
+    func configureBusColor(type: RouteType) -> UIColor? {
+        let color: UIColor?
+
+        switch type {
+        case .mainLine:
+            color = BBusColor.bbusTypeBlue
+            self.busIcon = BBusImage.blueBusIcon
+        case .broadArea:
+            color = BBusColor.bbusTypeRed
+            self.busIcon = BBusImage.redBusIcon
+        case .customized:
+            color = BBusColor.bbusTypeGreen
+            self.busIcon = BBusImage.greenBusIcon
+        case .circulation:
+            color = BBusColor.bbusTypeCirculation
+            self.busIcon = BBusImage.circulationBusIcon
+        case .lateNight:
+            color = BBusColor.bbusTypeBlue
+            self.busIcon = BBusImage.blueBusIcon
+        case .localLine:
+            color = BBusColor.bbusTypeGreen
+            self.busIcon = BBusImage.greenBusIcon
+        }
+
+        self.configureColor(to: color)
+        return color
+    }
+    
+    func configureBusTags(buses: [BusPosInfo]) {
+        self.busTags.forEach { $0.removeFromSuperview() }
+        self.busTags.removeAll()
+        
+        buses.forEach { [weak self] bus in
+            guard let self = self else { return }
+            let tag = self.createBusTag(location: bus.location,
+                                        busIcon: self.busIcon,
+                                        busNumber: bus.number,
+                                        busCongestion: bus.congestion.toString(),
+                                        isLowFloor: bus.islower)
+            self.busTags.append(tag)
+        }
+    }
+    
+    func configureBackButtonTitle(title: String) {
+        self.customNavigationBar.configureBackButtonTitle(title)
+    }
+    
+    func configureNavigationAlpha(alpha: CGFloat) {
+        self.customNavigationBar.configureAlpha(alpha: alpha)
     }
 }

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -16,7 +16,6 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
     
     private var cancellables: Set<AnyCancellable> = []
     private var lastContentOffset: CGFloat = 0
-    private var scrollDirection: Bool = false
 
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -45,6 +44,7 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        
         self.viewModel?.cancelObserver()
     }
 

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -10,14 +10,12 @@ import Combine
 
 final class HomeViewController: UIViewController, BaseViewControllerType {
 
-    private var lastContentOffset: CGFloat = 0
-
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel?
-
     private lazy var homeView = HomeView()
-
+    
     private var cancellables: Set<AnyCancellable> = []
+    private var lastContentOffset: CGFloat = 0
 
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -39,7 +37,6 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.viewModel?.loadHomeData()
         self.baseViewWillAppear()
         
         self.viewModel?.configureObserver()

--- a/BBus/BBus/Foreground/Home/HomeViewController.swift
+++ b/BBus/BBus/Foreground/Home/HomeViewController.swift
@@ -16,6 +16,7 @@ final class HomeViewController: UIViewController, BaseViewControllerType {
     
     private var cancellables: Set<AnyCancellable> = []
     private var lastContentOffset: CGFloat = 0
+    private var scrollDirection: Bool = false
 
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -11,33 +11,16 @@ import CoreLocation
 
 typealias MovingStatusCoordinator = MovingStatusOpenCloseDelegate & MovingStatusFoldUnfoldDelegate & AlertCreateToNavigationDelegate & AlertCreateToMovingStatusDelegate
 
-final class MovingStatusViewController: UIViewController {
-
+final class MovingStatusViewController: UIViewController, BaseViewControllerType {
+    
     static private let alarmIdentifier: String = "GetOffAlarm"
 
     weak var coordinator: MovingStatusCoordinator?
-    private lazy var movingStatusView = MovingStatusView()
     private let viewModel: MovingStatusViewModel?
-    private var cancellables: Set<AnyCancellable> = []
-    private var busTag: MovingStatusBusTagView?
-    private var color: UIColor?
-    private var busIcon: UIImage?
+    private lazy var movingStatusView = MovingStatusView()
     private var locationManager: CLLocationManager?
-
-    private lazy var refreshButton: ThrottleButton = {
-        let radius: CGFloat = 25
-
-        let button = ThrottleButton()
-        button.setImage(BBusImage.refresh, for: .normal)
-        button.layer.cornerRadius = radius
-        button.tintColor = BBusColor.white
-        button.backgroundColor = BBusColor.darkGray
-
-        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) { [weak self] in
-            self?.viewModel?.updateAPI()
-        }
-        return button
-    }()
+    
+    private var cancellables: Set<AnyCancellable> = []
 
     init(viewModel: MovingStatusViewModel) {
         self.viewModel = viewModel
@@ -51,12 +34,10 @@ final class MovingStatusViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.baseViewDidLoad()
 
         self.movingStatusView.startLoader()
-        self.binding()
-        self.configureLayout()
-        self.configureDelegate()
-        self.configureBusTag()
+        self.movingStatusView.configureBusTag()
         self.configureLocationManager()
         self.sendRequestAuthorization()
     }
@@ -90,8 +71,8 @@ final class MovingStatusViewController: UIViewController {
     }
     
     // MARK: - Configure
-    private func configureLayout() {
-        self.view.addSubviews(self.movingStatusView, self.refreshButton)
+    func configureLayout() {
+        self.view.addSubviews(self.movingStatusView)
         
         NSLayoutConstraint.activate([
             self.movingStatusView.topAnchor.constraint(equalTo: self.view.topAnchor),
@@ -99,44 +80,13 @@ final class MovingStatusViewController: UIViewController {
             self.movingStatusView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.movingStatusView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
         ])
-
-        let refreshButtonWidthAnchor: CGFloat = 50
-        let refreshBottomInterval: CGFloat = -MovingStatusView.endAlarmViewHeight
-        let refreshTrailingInterval: CGFloat = -16
-
-        NSLayoutConstraint.activate([
-            self.refreshButton.widthAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.heightAnchor.constraint(equalToConstant: refreshButtonWidthAnchor),
-            self.refreshButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: refreshTrailingInterval),
-            self.refreshButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: refreshBottomInterval)
-        ])
     }
     
-    private func configureDelegate() {
+    func configureDelegate() {
         self.movingStatusView.configureDelegate(self)
     }
-    
-    private func configureColor() {
-        self.view.backgroundColor = BBusColor.white
-    }
 
-    private func configureBusTag(bus: BoardedBus? = nil) {
-        self.busTag?.removeFromSuperview()
-
-        if let bus = bus {
-            self.busTag = self.movingStatusView.createBusTag(location: bus.location,
-                                                             color: self.color,
-                                                             busIcon: self.busIcon,
-                                                             remainStation: bus.remainStation)
-        }
-        else {
-            self.busTag = self.movingStatusView.createBusTag(color: self.color,
-                                                             busIcon: self.busIcon,
-                                                             remainStation: nil)
-        }
-    }
-
-    private func binding() {
+    func bindAll() {
         self.bindLoader()
         self.bindHeaderBusInfo()
         self.bindRemainTime()
@@ -163,8 +113,8 @@ final class MovingStatusViewController: UIViewController {
             .sink(receiveValue: { [weak self] busInfo in
                 guard let busInfo = busInfo else { return }
                 self?.movingStatusView.configureBusName(to: busInfo.busName)
-                self?.configureBusColor(type: busInfo.type)
-                self?.configureBusTag(bus: nil)
+                self?.movingStatusView.configureColorAndBusIcon(type: busInfo.type)
+                self?.movingStatusView.configureBusTag(bus: nil)
             })
             .store(in: &self.cancellables)
     }
@@ -200,7 +150,7 @@ final class MovingStatusViewController: UIViewController {
         self.viewModel?.$boardedBus
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] boardedBus in
-                self?.configureBusTag(bus: boardedBus)
+                self?.movingStatusView.configureBusTag(bus: boardedBus)
             })
             .store(in: &self.cancellables)
     }
@@ -225,31 +175,6 @@ final class MovingStatusViewController: UIViewController {
                 }
             })
             .store(in: &self.cancellables)
-    }
-
-    private func configureBusColor(type: RouteType) {
-        switch type {
-        case .mainLine:
-            self.color = BBusColor.bbusTypeBlue
-            self.busIcon = BBusImage.blueBooduckBus
-        case .broadArea:
-            self.color = BBusColor.bbusTypeRed
-            self.busIcon = BBusImage.redBooduckBus
-        case .customized:
-            self.color = BBusColor.bbusTypeGreen
-            self.busIcon = BBusImage.greenBooduckBus
-        case .circulation:
-            self.color = BBusColor.bbusTypeCirculation
-            self.busIcon = BBusImage.circulationBooduckBus
-        case .lateNight:
-            self.color = BBusColor.bbusTypeBlue
-            self.busIcon = BBusImage.blueBooduckBus
-        case .localLine:
-            self.color = BBusColor.bbusTypeGreen
-            self.busIcon = BBusImage.greenBooduckBus
-        }
-
-        self.movingStatusView.configureColor(to: color)
     }
     
     private func bindErrorMessage() {
@@ -301,6 +226,9 @@ final class MovingStatusViewController: UIViewController {
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }
 
+    func refresh() {
+        self.viewModel?.updateAPI()
+    }
 }
 
 // MARK: - DataSource: UITableView
@@ -354,6 +282,13 @@ extension MovingStatusViewController: FoldButtonDelegate {
 extension MovingStatusViewController: EndAlarmButtonDelegate {
     func shouldEndAlarm() {
         self.coordinator?.close()
+    }
+}
+
+// MARK: - Delegate: RefreshButton
+extension MovingStatusViewController: RefreshButtonDelegate {
+    func buttonTapped() {
+        self.refresh()
     }
 }
 

--- a/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
+++ b/BBus/BBus/Foreground/MovingStatus/MovingStatusViewController.swift
@@ -187,6 +187,10 @@ final class MovingStatusViewController: UIViewController, BaseViewControllerType
             .store(in: &self.cancellables)
     }
     
+    func refresh() {
+        self.viewModel?.updateAPI()
+    }
+    
     private func networkAlert() {
         let controller = UIAlertController(title: "네트워크 장애", message: "네트워크 장애가 발생하여 앱이 정상적으로 동작되지 않습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "확인", style: .default, handler: nil)
@@ -224,10 +228,6 @@ final class MovingStatusViewController: UIViewController, BaseViewControllerType
         content.badge = Int(truncating: content.badge ?? 0) + 1 as NSNumber
         let request = UNNotificationRequest(identifier: Self.alarmIdentifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
-    }
-
-    func refresh() {
-        self.viewModel?.updateAPI()
     }
 }
 

--- a/BBus/BBus/Foreground/Station/View/StationView.swift
+++ b/BBus/BBus/Foreground/Station/View/StationView.swift
@@ -37,14 +37,42 @@ final class StationView: UIView {
         let loader = UIActivityIndicatorView(style: .large)
         return loader
     }()
+    private lazy var customNavigationBar: CustomNavigationBar = {
+        let bar = CustomNavigationBar()
+        bar.configureTintColor(color: BBusColor.white)
+        if let bbusGray = BBusColor.bbusGray {
+            bar.configureBackgroundColor(color: bbusGray)
+        }
+        bar.configureAlpha(alpha: 0)
+        return bar
+    }()
+    
+    private lazy var refreshButton: ThrottleButton = {
+        let radius: CGFloat = 25
+
+        let button = ThrottleButton()
+        button.setImage(BBusImage.refresh, for: .normal)
+        button.layer.cornerRadius = radius
+        button.tintColor = UIColor.white
+        button.backgroundColor = UIColor.darkGray
+        button.addTouchUpEventWithThrottle(delay: ThrottleButton.refreshInterval) { [weak self] in
+//            self?.viewModel?.refresh()
+        }
+        return button
+    }()
 
     convenience init() {
         self.init(frame: CGRect())
         
+        self.configureColor()
         self.configureLayout()
     }
 
     // MARK: - Configure
+    private func configureColor() {
+        self.backgroundColor = BBusColor.white
+    }
+    
     private func configureLayout() {
         let half: CGFloat = 0.5
         
@@ -96,10 +124,11 @@ final class StationView: UIView {
         ])
     }
 
-    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UIScrollViewDelegate) {
+    func configureDelegate(_ delegate: UICollectionViewDelegate & UICollectionViewDataSource & UIScrollViewDelegate & BackButtonDelegate) {
         self.stationBodyCollectionView.delegate = delegate
         self.stationBodyCollectionView.dataSource = delegate
         self.stationScrollView.delegate = delegate
+        self.customNavigationBar.configureDelegate(delegate)
     }
 
     func configureTableViewHeight(height: CGFloat?) -> NSLayoutConstraint {
@@ -142,5 +171,9 @@ final class StationView: UIView {
     func stopLoader() {
         self.loader.isHidden = true
         self.loader.stopAnimating()
+    }
+    
+    func configureNavigationAlpha(alpha: CGFloat) {
+        self.customNavigationBar.configureAlpha(alpha: alpha)
     }
 }

--- a/BBus/BBus/Global/CustomView/CustomNavigationBar.swift
+++ b/BBus/BBus/Global/CustomView/CustomNavigationBar.swift
@@ -89,7 +89,7 @@ final class CustomNavigationBar: UIView {
     }
 
     // MARK: - Configure NavigationBar
-    func configureTintColor(color: UIColor) {
+    func configureTintColor(color: UIColor?) {
         self.backButton.tintColor = color
         self.backButtonTitleLabel.textColor = color
         self.titleLabel.textColor = color

--- a/BBus/BBus/Global/CustomView/RefreshableView.swift
+++ b/BBus/BBus/Global/CustomView/RefreshableView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol RefreshButtonDelegate {
+protocol RefreshButtonDelegate: AnyObject {
     func buttonTapped()
 }
 


### PR DESCRIPTION
## 작업 내용
- [x] Foreground의 모든 ViewController가 BaseViewControllerType을 채택하도록 리팩토링

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 모든 뷰 관련 프로퍼티를 [각씬이름]View() 내부로 집어넣음.
- busRouteType을 받아 view의 컬러를 바꾸는 메소드 `configureColor(routeType:)`를 ViewController -> View 쪽으로 이동시킴. 관련 뷰를 ViewController->View로 이동시켰으므로 해당 메소드도 뷰로 이동되어야 한다고 판단.
- Refresh 버튼과 CustomNavigationBar는 추후 프로토콜화 되어 각 뷰컨트롤러에서 구현할 필요없으므로 `addSubview()`는 하지 않아 화면에 보이지 않는 상태임.