### PR TITLE
[테스트] TokenManager 테스트

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		04045B812740F6DC0056A433 /* BusSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04045B802740F6DC0056A433 /* BusSearchResult.swift */; };
 		041A5A11273D2E1B00490075 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041A5A10273D2E1B00490075 /* StringExtension.swift */; };
 		04214061273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04214060273A5EBC00A15423 /* MovingStatusFoldUnfoldDelegate.swift */; };
+		0446840C275650B0007E440A /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5182A32754E3CA001EA530 /* TokenManager.swift */; };
+		0446840D2756597F007E440A /* BBusAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A38E20627463FF7003A9D10 /* BBusAPIError.swift */; };
 		0451EDB42755BBBD00031A16 /* SearchCalculateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0451EDB32755BBBD00031A16 /* SearchCalculateUseCase.swift */; };
 		0476ABBB27310ED200F72DD1 /* BusRouteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476ABBA27310ED200F72DD1 /* BusRouteHeaderView.swift */; };
 		0476ABBD27311C1600F72DD1 /* BusStationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476ABBC27311C1600F72DD1 /* BusStationTableViewCell.swift */; };
@@ -1628,7 +1630,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0446840D2756597F007E440A /* BBusAPIError.swift in Sources */,
 				4AF1E0822756263E00DE51C8 /* TokenManagerTests.swift in Sources */,
+				0446840C275650B0007E440A /* TokenManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BBus/TokenManagerTests/TokenManagerTests.swift
+++ b/BBus/TokenManagerTests/TokenManagerTests.swift
@@ -8,25 +8,63 @@
 import XCTest
 
 class TokenManagerTests: XCTestCase {
+    var tokenManager: TokenManager!
+    var accessKeyList: [String]!
+    
+    enum APIAccessKeyError: Error {
+        case cannotFindAccessKey
+    }
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        self.tokenManager = TokenManager()
+        self.accessKeyList = try self.loadAllAccessKeys()
+        
+        super.setUp()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        self.tokenManager = nil
+        self.accessKeyList = nil
+        super.tearDown()
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    func loadAllAccessKeys() throws -> [String] {
+        var accessKeyList = [String]()
+        
+        for i in (1...TokenManager.maxTokenCount) {
+            guard let accessKey = Bundle.main.infoDictionary?["API_ACCESS_KEY\(i)"] as? String else { throw APIAccessKeyError.cannotFindAccessKey }
+            accessKeyList.append(accessKey)
+        }
+        
+        return accessKeyList
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
+    
+    func test_randomAccessKey_리턴_성공() {
+        // given
+        let expectedMinIndex = 0
+        let expectedMaxIndex = 16
+        
+        // when then
+        do {
+            let randomAccessKey = try self.tokenManager.randomAccessKey()
+            let index = randomAccessKey.index
+            let key = randomAccessKey.key
+            
+            XCTAssertGreaterThanOrEqual(index, expectedMinIndex)
+            XCTAssertLessThanOrEqual(index, expectedMaxIndex)
+            XCTAssertTrue(self.accessKeyList.contains(key))
+        } catch {
+            XCTFail()
         }
     }
-
+    
+    func test_randomAccessKey_액세스키_없어_리턴_실패() {
+        // given
+        for i in (0..<TokenManager.maxTokenCount) {
+            self.tokenManager.removeAccessKey(at: i)
+        }
+        
+        // when then
+        XCTAssertThrowsError(try self.tokenManager.randomAccessKey())
+    }
 }


### PR DESCRIPTION
## 작업 내용
- [x] `randomAccessKey()`  메소드 성공/실패 경우 테스트

## 시연 방법

## 기타 (고민과 해결, 리뷰 포인트 등)
- 모두 private 처리 되어있어서 쓸 수 있는 메소드가 `removeAccessKey(at:)`과 `randomAccessKey()` 밖에 없었음.
- 각 메소드를 테스트하기 위해서는 서로를 사용할 수 밖에 없는 구조라는 문제가 있음.
-  A가 무결하다는 것을 증명하기 위해서 무결함이 증명된 B를 사용해야하는데 B가 무결하다는 것을 증명하기 위해서는 무결하다고 증명된 A를 사용해야한다?
- `randomAccessKey()`를 테스트하기 위해서 `removeAccessKey(at:)`을 17번 호출하여 `keys`를 비운 뒤 `randomAccessKey()`를 호출했을 때 error를 잘 throw하는지 체크한다.
- `removeAccessKey(at:)`을 테스트하기 위해서 17번 호출하여 keys를 비운 뒤 `randomAccesssKey()`를 호출하여 진짜로 비워졌는지 체크한다.(에러가 캐치되면 비워진 것)
- 순환을 이루는 이상한 테스트 구조가 되어버림.
- `removeAccessKey(at:)`은 간단한 filter 로직밖에 없어 무결하다고 가정하고 이를 사용하여 `randomAccessKey()`만 테스트하였음.